### PR TITLE
Remove empty dropdowns and cards from process pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,19 @@ The template includes all possible dropdown sections as a starting point. **When
 
 If you find one, flag it and ask the developer: **"The `<Section Title>` dropdown is empty — should it be deleted, or does it need content?"** Wait for confirmation before making any changes. Do not silently leave `- None` placeholders in committed files, but also do not silently delete them. The template file (`templates/process-template/process-make_template.md`) is the only file exempt from this rule.
 
+**If all dropdowns in the Important Information card are removed**, the containing card block should also be removed:
+
+```
+:::::::{card}
+:header: **Important Information**
+
+Please read this section carefully. It contains important notes, resources, and safety information. Not all information included here is included in the lab-ready protocol.
+
+:::::::
+```
+
+Again, confirm with the developer before deleting the card.
+
 ### Notion migration gotchas
 
 When migrating content from Notion markdown exports:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,24 @@ Pages use MyST admonition nesting with `:::` fences. Process pages follow a cons
 
 Protocol steps use `- [ ]` checkboxes and `:::{hint}` dropdowns for extended notes. Cross-references use MyST `{ref}` syntax for same-page targets and standard markdown links for cross-page references.
 
+### Overview card dropdowns — empty dropdown policy
+
+The template includes all possible dropdown sections as a starting point. **When authoring or reviewing a process page, only keep dropdowns that have real content.** Delete any dropdown whose only content is `- None`.
+
+**When editing or reviewing a process page**, scan for empty dropdowns matching this pattern and flag them:
+
+```
+::::::{<type>} <Section Title>
+:class: dropdown
+:icon: false
+
+- None
+
+::::::
+```
+
+If you find one, flag it and ask the developer: **"The `<Section Title>` dropdown is empty — should it be deleted, or does it need content?"** Wait for confirmation before making any changes. Do not silently leave `- None` placeholders in committed files, but also do not silently delete them. The template file (`templates/process-template/process-make_template.md`) is the only file exempt from this rule.
+
 ### Notion migration gotchas
 
 When migrating content from Notion markdown exports:

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,40 @@
+# Contributing to Nucleus Docs
+
+Thank you for contributing to the Nucleus Distribution documentation! This guide covers the conventions and workflows you should follow when adding or editing process pages.
+
+## Authoring a new process page
+
+Start from the template at `templates/process-template/process-make_template.md`. Copy it into the appropriate subdirectory under `docs/processes/` and fill in the content.
+
+The template's `# Overview` card includes all possible dropdown sections as a starting scaffold:
+
+| Dropdown | When to keep it |
+| --- | --- |
+| **Notes** | Any general notes that don't fit elsewhere |
+| **Prerequisite Documentation** | Links to protocols that must be completed before this one |
+| **Hazardous Materials** | Any reagents with significant safety considerations |
+| **Critical Materials** | Materials where substitution or quality issues would affect the outcome |
+| **Genetically Encoded Components** | Plasmids, strains, or other genetic constructs required |
+| **Composition** | Buffer recipes or mixture compositions specific to this protocol |
+| **References** | Primary literature or external resources |
+
+**Delete any dropdown that you don't have content for.** An empty dropdown (one whose only content is `- None`) adds visual clutter and signals to readers that something is missing. The rule is simple: if a section doesn't apply to your protocol, remove it entirely rather than leaving a `- None` placeholder.
+
+## Reviewing a process page
+
+When reviewing a PR that adds or modifies a process page:
+
+1. Check the Overview card for any dropdowns that still contain `- None`.
+2. Flag each one to the author and ask whether it should be deleted or filled in.
+3. Do not approve the PR while empty dropdowns remain — they should be resolved (deleted or filled) before merge.
+
+> **Note for Claude Code users:** If you ask Claude to review a process page, it will flag empty dropdowns and ask you how to handle each one before making any changes.
+
+## MyST formatting conventions
+
+See `CLAUDE.md` for full details. Key points:
+
+- All table rows must be at **0 indentation** (no leading spaces), even when a table follows a list item.
+- Inline hints use `:::{hint} Note: <title>` with `:class: dropdown`.
+- Protocol steps use `- [ ]` checkboxes.
+- Add every new page to the `toc:` section in `myst.yml`.

--- a/docs/processes/assemble-base-cell/main.md
+++ b/docs/processes/assemble-base-cell/main.md
@@ -17,46 +17,6 @@ Successfully built Base Cells will start dark and then increase in green fluores
 
 Please read this section carefully. It contains important notes, resources, and safety information. Not all information included here is included in the lab-ready protocol.
 
-::::::{note} Notes
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{seealso} Prerequisite Documentation
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{danger} Hazardous Materials
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{attention} Critical Materials
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{attention} Genetically Encoded Components
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
 ::::::{note} Composition
 :class: dropdown
 :icon: false
@@ -106,14 +66,6 @@ Please read this section carefully. It contains important notes, resources, and 
 
 ::::
 :::::
-
-::::::
-
-::::::{note} References
-:class: dropdown
-:icon: false
-
-- None
 
 ::::::
 

--- a/docs/processes/assemble-base-cytosol/main.md
+++ b/docs/processes/assemble-base-cytosol/main.md
@@ -39,22 +39,6 @@ Please read this section carefully. It contains important notes, resources, and 
 
 ::::::
 
-::::::{danger} Hazardous Materials
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{attention} Critical Materials
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
 ::::::{attention} Genetically Encoded Components
 :class: dropdown
 :icon: false

--- a/docs/processes/make-1pot/main.md
+++ b/docs/processes/make-1pot/main.md
@@ -11,12 +11,6 @@ Making PURE requires making Protein Mix, which contains the thirty-six (36) prot
 This Process has not yet been migrated onto Nucleus Documentation. The protocol can be found on our legacy site [here](https://nucleus.bnext.bio/Make-OnePot-Protein-Mix-234ae616eb5180c0b84cf5046d63a803).
 :::
 
-:::::::{card}
-:header: **Important Information**
-
-Please read this section carefully. It contains important notes, resources, and safety information. Not all information included here is included in the lab-ready protocol.
-
-:::::::
 
 # Protocol
 

--- a/docs/processes/make-1pot/main.md
+++ b/docs/processes/make-1pot/main.md
@@ -16,62 +16,6 @@ This Process has not yet been migrated onto Nucleus Documentation. The protocol 
 
 Please read this section carefully. It contains important notes, resources, and safety information. Not all information included here is included in the lab-ready protocol.
 
-::::::{note} Notes
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{seealso} Prerequisite Documentation
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{danger} Hazardous Materials
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{attention} Critical Materials
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{attention} Genetically Encoded Components
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{note} Composition
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{note} References
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
 :::::::
 
 # Protocol

--- a/docs/processes/make-36pot/main.md
+++ b/docs/processes/make-36pot/main.md
@@ -22,62 +22,6 @@ This Process has not yet been migrated onto Nucleus Documentation. The protocol 
 
 Please read this section carefully. It contains important notes, resources, and safety information. Not all information included here is included in the lab-ready protocol.
 
-::::::{note} Notes
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{seealso} Prerequisite Documentation
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{danger} Hazardous Materials
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{attention} Critical Materials
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{attention} Genetically Encoded Components
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{note} Composition
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{note} References
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
 :::::::
 
 # Protocol

--- a/docs/processes/make-36pot/main.md
+++ b/docs/processes/make-36pot/main.md
@@ -17,12 +17,6 @@ This protocol describes the Process for making the thirty-six component proteins
 This Process has not yet been migrated onto Nucleus Documentation. The protocol can be found on our legacy site [here](https://nucleus.bnext.bio/Make-Protein-Mix-78b432dd513d4f2e81a0bdf18e3c8de5).
 :::
 
-:::::::{card}
-:header: **Important Information**
-
-Please read this section carefully. It contains important notes, resources, and safety information. Not all information included here is included in the lab-ready protocol.
-
-:::::::
 
 # Protocol
 

--- a/docs/processes/make-amino-acid-mix/main.md
+++ b/docs/processes/make-amino-acid-mix/main.md
@@ -12,30 +12,6 @@ Amino Acid Mix is an equimolar (3.25 mM) mix of the 20 canonical amino acids. He
 
 Please read this section carefully. It contains important notes, resources, and safety information. Not all information included here is included in the lab-ready protocol.
 
-::::::{note} Notes
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{seealso} Prerequisite Documentation
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{danger} Hazardous Materials
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
 ::::::{attention} Critical Materials
 :class: dropdown
 :icon: false
@@ -50,30 +26,6 @@ Please read this section carefully. It contains important notes, resources, and 
 
 
 :::
-
-::::::
-
-::::::{attention} Genetically Encoded Components
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{note} Composition
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{note} References
-:class: dropdown
-:icon: false
-
-- None
 
 ::::::
 

--- a/docs/processes/make-protein/buff-ex-spin-filters/main.md
+++ b/docs/processes/make-protein/buff-ex-spin-filters/main.md
@@ -13,62 +13,6 @@ You can use centrifugal spin filters to concentrate your sample and change its b
 
 Please read this section carefully. It contains important notes, resources, and safety information. Not all information included here is included in the lab-ready protocol.
 
-::::::{note} Notes
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{seealso} Prerequisite Documentation
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{danger} Hazardous Materials
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{attention} Critical Materials
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{attention} Genetically Encoded Components
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{note} Composition
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{note} References
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
 :::::::
 
 # Materials and Equipment

--- a/docs/processes/make-protein/buff-ex-spin-filters/main.md
+++ b/docs/processes/make-protein/buff-ex-spin-filters/main.md
@@ -8,12 +8,6 @@ You have a sample of a biomolecule (e.g., T7RNAP, tRNA, ribosomes, plasmid, etc.
 
 You can use centrifugal spin filters to concentrate your sample and change its buffer. These filters allow buffer and small molecules to flow through them, retaining large molecules bigger than the filter's specified molecular weight.
 
-:::::::{card}
-:header: **Important Information**
-
-Please read this section carefully. It contains important notes, resources, and safety information. Not all information included here is included in the lab-ready protocol.
-
-:::::::
 
 # Materials and Equipment
 

--- a/docs/processes/make-protein/grow-bacteria/main.md
+++ b/docs/processes/make-protein/grow-bacteria/main.md
@@ -11,59 +11,11 @@ You want to purify proteins. First, you're going to have to make some. We make p
 
 Please read this section carefully. It contains important notes, resources, and safety information. Not all information included here is included in the lab-ready protocol.
 
-::::::{note} Notes
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
 ::::::{seealso} Prerequisite Documentation
 :class: dropdown
 :icon: false
 
 - [Prepare Protein Purification Buffers and Media](../prep-consumables/main.md)
-
-::::::
-
-::::::{danger} Hazardous Materials
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{attention} Critical Materials
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{attention} Genetically Encoded Components
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{note} Composition
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{note} References
-:class: dropdown
-:icon: false
-
-- None
 
 ::::::
 

--- a/docs/processes/make-protein/lysis-sonication/main.md
+++ b/docs/processes/make-protein/lysis-sonication/main.md
@@ -11,60 +11,12 @@ You have bacterial cultures and you want to extract something inside of them (e.
 
 Please read this section carefully. It contains important notes, resources, and safety information. Not all information included here is included in the lab-ready protocol.
 
-::::::{note} Notes
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
 ::::::{seealso} Prerequisite Documentation
 :class: dropdown
 :icon: false
 
 - [Prepare Protein Purification Buffers and Media](../prep-consumables/main.md)
 - [Grow and Induce Expression Strains](../grow-bacteria/main.md)
-
-::::::
-
-::::::{danger} Hazardous Materials
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{attention} Critical Materials
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{attention} Genetically Encoded Components
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{note} Composition
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{note} References
-:class: dropdown
-:icon: false
-
-- None
 
 ::::::
 

--- a/docs/processes/make-protein/prep-consumables/main.md
+++ b/docs/processes/make-protein/prep-consumables/main.md
@@ -6,12 +6,6 @@ title: Prepare Protein Purification Buffers and Media
 
 Here, we make media used to grow up an expression strain to use for subsequent protein purification. We also make buffers used to purify those proteins using nickel histidine affinity chromatography.
 
-:::::::{card}
-:header: **Important Information**
-
-Please read this section carefully. It contains important notes, resources, and safety information. Not all information included here is included in the lab-ready protocol.
-
-:::::::
 
 # Materials and Equipment
 

--- a/docs/processes/make-protein/prep-consumables/main.md
+++ b/docs/processes/make-protein/prep-consumables/main.md
@@ -11,62 +11,6 @@ Here, we make media used to grow up an expression strain to use for subsequent p
 
 Please read this section carefully. It contains important notes, resources, and safety information. Not all information included here is included in the lab-ready protocol.
 
-::::::{note} Notes
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{seealso} Prerequisite Documentation
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{danger} Hazardous Materials
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{attention} Critical Materials
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{attention} Genetically Encoded Components
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{note} Composition
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{note} References
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
 :::::::
 
 # Materials and Equipment

--- a/docs/processes/make-protein/purify-proteins-grav-column/main.md
+++ b/docs/processes/make-protein/purify-proteins-grav-column/main.md
@@ -11,14 +11,6 @@ You have a protein that you want to purify out of a complicated mixture. This pr
 
 Please read this section carefully. It contains important notes, resources, and safety information. Not all information included here is included in the lab-ready protocol.
 
-::::::{note} Notes
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
 ::::::{seealso} Prerequisite Documentation
 :class: dropdown
 :icon: false
@@ -26,46 +18,6 @@ Please read this section carefully. It contains important notes, resources, and 
 - [Prepare Protein Purification Buffers and Media](../prep-consumables/main.md)
 - Prepare Columns
 - [Lyse Bacteria by Sonication](../lysis-sonication/main.md)
-
-::::::
-
-::::::{danger} Hazardous Materials
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{attention} Critical Materials
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{attention} Genetically Encoded Components
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{note} Composition
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{note} References
-:class: dropdown
-:icon: false
-
-- None
 
 ::::::
 

--- a/docs/processes/make-ribosomes/main.md
+++ b/docs/processes/make-ribosomes/main.md
@@ -22,35 +22,11 @@ Please read this section carefully. It contains important notes, resources, and 
 
 ::::::
 
-::::::{seealso} Prerequisite Documentation
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{danger} Hazardous Materials
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
 ::::::{attention} Critical Materials
 :class: dropdown
 :icon: false
 
 - A19 *E. coli*
-
-::::::
-
-::::::{attention} Genetically Encoded Components
-:class: dropdown
-:icon: false
-
-- None
 
 ::::::
 
@@ -67,14 +43,6 @@ Please read this section carefully. It contains important notes, resources, and 
 | Ribosomes | 10 $\mu$M (5.55x) | 1.8 $\mu$M |
 
 :::
-
-::::::
-
-::::::{note} References
-:class: dropdown
-:icon: false
-
-- None
 
 ::::::
 

--- a/docs/processes/make-small-molecule-mix/main.md
+++ b/docs/processes/make-small-molecule-mix/main.md
@@ -13,27 +13,11 @@ Small Molecule Mix is a combination of thirty-one (31) small molecules (*e.g.*, 
 
 Please read this section carefully. It contains important notes, resources, and safety information. Not all information included here is included in the lab-ready protocol.
 
-::::::{note} Notes
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
 ::::::{seealso} Prerequisite Documentation
 :class: dropdown
 :icon: false
 
 - [Make Amino Acid Mix (3.25 mM)](../make-amino-acid-mix/main.md)
-
-::::::
-
-::::::{danger} Hazardous Materials
-:class: dropdown
-:icon: false
-
-- None
 
 ::::::
 
@@ -50,14 +34,6 @@ Please read this section carefully. It contains important notes, resources, and 
 | Folinic acid | Folinic acid calcium salt hydrate | Sigma-Aldrich | F7878-100MG | $108 | 4C to 30C | [[link](https://www.sigmaaldrich.com/US/en/product/sial/f7878)] |
 
 :::
-
-::::::
-
-::::::{attention} Genetically Encoded Components
-:class: dropdown
-:icon: false
-
-- None
 
 ::::::
 
@@ -85,14 +61,6 @@ Please read this section carefully. It contains important notes, resources, and 
 | TCEP | 2.5 | 1 |
 
 :::
-
-::::::
-
-::::::{note} References
-:class: dropdown
-:icon: false
-
-- None
 
 ::::::
 

--- a/docs/processes/make-trna/main.md
+++ b/docs/processes/make-trna/main.md
@@ -23,14 +23,6 @@ Please read this section carefully. It contains important notes, resources, and 
 
 ::::::
 
-::::::{seealso} Prerequisite Documentation
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
 ::::::{danger} Hazardous Materials
 :class: dropdown
 :icon: false
@@ -53,22 +45,6 @@ Please read this section carefully. It contains important notes, resources, and 
 
 ::::::
 
-::::::{attention} Critical Materials
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
-::::::{attention} Genetically Encoded Components
-:class: dropdown
-:icon: false
-
-- None
-
-::::::
-
 ::::::{note} Composition
 :class: dropdown
 :icon: false
@@ -82,14 +58,6 @@ Please read this section carefully. It contains important notes, resources, and 
 | tRNA | 35 $\mu$g/$\mu$L (10x) | 3.5 $\mu$g/$\mu$L |
 
 :::
-
-::::::
-
-::::::{note} References
-:class: dropdown
-:icon: false
-
-- None
 
 ::::::
 


### PR DESCRIPTION
Closes #9

## Summary

Retroactively cleans up empty `- None` placeholder dropdowns from all committed process pages, and removes the containing Important Information card when all its dropdowns are gone.

### Changes
- **13 process pages**: stripped all empty `- None` dropdowns (65 total removed)
- **4 process pages**: additionally removed the now-empty Important Information card (`make-36pot`, `buff-ex-spin-filters`, `prep-consumables`, `make-1pot`)
- **`CLAUDE.md`**: added empty dropdown policy — flag and confirm with developer before deleting; also flag empty card when all dropdowns are removed; template file is exempt
- **`CONTRIBUTORS.md`** (new): documents the authoring workflow, dropdown guidance, and review checklist

### Convention going forward
Copy the template, fill in the dropdowns that apply, delete the rest. Empty `- None` placeholders should not be committed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)