### PR TITLE
Feature/add vale

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,5 @@
+StylesPath = styles
+MinAlertLevel = warning
+
+[*.md]
+BasedOnStyles = nucleus

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,27 @@ When migrating content from Notion markdown exports:
 
 `myst.yml` maintains a `references:` map of named keys (e.g., `devnote-01:`) pointing to external DevNote URLs. These can be cited throughout the docs without repeating URLs.
 
+### Prose linting (Vale)
+
+Run Vale to check docs for style violations:
+
+```bash
+vale docs/          # lint all docs
+vale <file.md>      # lint a single file
+```
+
+Vale rules live in `styles/nucleus/`. Current rules enforce temperature unit formatting (`°C`).
+
+**Interpreting `nucleus.degrees-symbol` errors.** This rule flags patterns like `37C` or `4 C` that are missing the degree symbol. However, it cannot distinguish temperatures from alphanumeric labels, so it produces false positives. When Vale flags a `nucleus.degrees-symbol` error, check the surrounding context:
+
+- **Real error** — the token is a temperature value. Fix it by adding the degree symbol (e.g., `37C` → `37°C`, `4 C` → `4°C`).
+  - Signals: preceded by "at", "to", "of", or a verb like "incubate", "store", "heat"; followed by "for X minutes/hours"; in a reaction table or thermocycler step.
+  - **Table cells**: a bare value (e.g., `37C`) in a table column whose header indicates temperature (e.g., "Temperature", "Incubation temp", "Storage") is always a real error, even without surrounding signal words.
+- **False positive** — the token is a label, not a temperature. Leave it alone.
+  - Signals: preceded by "Figure", "Fig.", "Step", "Lane", "Panel", "Tube", "Option", or a similar structural label word.
+
+Do not add Vale inline suppression comments (`<!-- vale off -->`) without confirming with the developer first.
+
 ### Pull request workflow
 
 When merging a PR via `gh pr merge`, never use `--admin` to bypass branch protection rules. If a merge fails due to branch policy, stop and ask the developer how to proceed — options are leaving the PR open for a reviewer, asking the developer to approve it themselves, or using `--auto` to merge once requirements are met.

--- a/setup.sh
+++ b/setup.sh
@@ -6,6 +6,11 @@ if [[ "$CONDA_DEFAULT_ENV" == "nucleus-docs" ]]; then
   exit 1
 fi
 
+# Install Vale if not already present
+if ! command -v vale &> /dev/null; then
+  brew install vale
+fi
+
 conda env remove -n nucleus-docs 2>/dev/null
 conda env create -f environment.yml
 echo ""

--- a/styles/nucleus/degrees-symbol.yml
+++ b/styles/nucleus/degrees-symbol.yml
@@ -1,0 +1,5 @@
+extends: existence
+message: "Use the degree symbol: '°C' instead of '%s'."
+level: error
+raw:
+  - '\d+\s*C\b'

--- a/styles/nucleus/micro-symbol.yml
+++ b/styles/nucleus/micro-symbol.yml
@@ -1,0 +1,5 @@
+extends: existence
+message: "Use the micro symbol (mu): '%s' should be written with 'µ' not 'u' (e.g., uL -> µL, uM -> µM, um -> µm)."
+level: error
+raw:
+  - '\d+\s*u[LMm]\b'

--- a/styles/nucleus/units.yml
+++ b/styles/nucleus/units.yml
@@ -1,0 +1,11 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+level: error
+swap:
+  degC: °C
+  deg C: °C
+  degrees C: °C
+  degrees Celsius: °C
+  degrees celsius: °C
+  deg. C: °C
+  degc: °C

--- a/styles/tests/micro-symbol.md
+++ b/styles/tests/micro-symbol.md
@@ -1,0 +1,20 @@
+# Micro Symbol Test
+
+## Should fire (bad examples)
+
+Add 10 uL of buffer.
+Dilute to 500 uM final concentration.
+The bead diameter is 2 um.
+Mix 0.5 uL with 100 uM stock.
+
+## Should NOT fire (correct µ symbol)
+
+Add 10 µL of buffer.
+Dilute to 500 µM final concentration.
+The bead diameter is 2 µm.
+
+## Should NOT fire (non-unit uses of 'um')
+
+Um, that's a good question.
+Add to the medium before proceeding.
+The maximum volume is 25 µL.

--- a/styles/tests/temperature.md
+++ b/styles/tests/temperature.md
@@ -1,0 +1,13 @@
+# Temperature Test
+
+## Simple tests
+
+Incubate at 37 degC for 1 hour.
+Cool samples to 4 degrees C before proceeding.
+Store at -20 degrees Celsius overnight.
+The reaction runs at 30 deg C.
+Set the thermocycler to 95C for denaturation.
+Hold at 72 C for extension.
+We use vitamin C in the buffer.
+See option C for details.
+The correct way: incubate at 37°C.

--- a/styles/tests/temperature.md
+++ b/styles/tests/temperature.md
@@ -11,3 +11,9 @@ Hold at 72 C for extension.
 We use vitamin C in the buffer.
 See option C for details.
 The correct way: incubate at 37°C.
+
+## Known false positives (should NOT fire, but currently do)
+
+See Figure 2C for the gel image.
+Refer to Step 1C in the protocol.
+Lane 3C shows the control band.


### PR DESCRIPTION
## add vale linter for docs style enforcement

Branch addresses Issue #8 

Introduces vale as a prose linter for the nucleus docs, starting with a minimal custom rule set to validate before scaling up.

### changes

- `.vale.ini` — config file pointing to a `styles/nucleus/` directory, scoped to all `.md` files
- `styles/nucleus/units.yml` — substitution rule enforcing `°C` over spelled-out variants (`degc`, `degrees celsius`, etc.)
- `styles/nucleus/degrees-symbol.yml` — regex rule catching bare `37 C` / `95C` patterns that the substitution rule misses
- `test.md` — throwaway test file with good and bad examples to verify the rules work
- `setup.sh` — adds vale install check via homebrew

### usage

```bash
./setup.sh          # installs vale if missing
vale test.md        # verify rules work
vale docs/          # run against real content
```

### what's next

This is the foundation for tier 1 of the docs style enforcement plan. next steps:
- add terminology rules (deGFP, aTc, IV-HSL, PURE system, etc.)
- add voice/tone rules (banned phrases, conciseness)
- add CI integration via `errata-ai/vale-action`
- remove `test.md` once we're confident in the rules