### PR TITLE
Add file placement guidance to CLAUDE.md (closes #30)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,18 @@ The documentation organizes content into three parallel hierarchies under `docs/
 - **`docs/modules/`** — Modular components that extend base cytosol functionality. Each module has a `spec.md` describing its design, compatible processes, and usage.
 - **`docs/implementations/`** — Documented combinations of modules and processes that demonstrate a complete system behavior.
 
+**File placement rules.** All content files — `.md`, images, `.csv` resources — must live inside one of these three subdirectories. Never create content files or directories at the repo root or anywhere outside `docs/`.
+
+| Content type | Correct location |
+| --- | --- |
+| New module | `docs/modules/<module-name>/` |
+| New process | `docs/processes/<process-name>/` |
+| New implementation | `docs/implementations/<implementation-name>/` |
+| Process sub-resources (BOMs, images) | `docs/processes/<process-name>/resources/` |
+| Module images | `docs/modules/<module-name>/` |
+
+**Before creating or moving any file**, verify the target path matches this structure. If a file is about to land outside `docs/`, stop and flag it to the developer before proceeding.
+
 ### Table of contents management
 
 The site TOC is defined entirely in `myst.yml`. When adding a new page, you must add it to the `toc:` section. Child pages that should not appear directly in the sidebar use `hidden: true`. The file `site.yml` holds site-wide settings (license, nav links, theme) that `myst.yml` extends.


### PR DESCRIPTION
## Summary

Closes #30.

Adds explicit file placement rules to CLAUDE.md to prevent content files from being accidentally created outside `docs/`.

### Background

During PR #23 (PPK module migration), an empty `energy-ppk/` directory was accidentally created at the repo root. The actual files landed correctly under `docs/modules/energy-ppk/`, but nothing in CLAUDE.md told contributors (or Claude) where new files should go.

### Changes

- **CLAUDE.md** — adds a "File placement rules" section to the Content model with:
  - A reference table mapping content type to correct path
  - An explicit pre-flight instruction to verify target path before creating or moving any file
  - A hard rule: nothing goes outside `docs/`

- **Local cleanup** — removed the stray empty `./energy-ppk/` directory (was untracked by git, so no commit needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)