### PR TITLE
Fix dead links found during lychee link-checking spike (closes #33)

### DIFF
--- a/docs/modules/control-clpxp/spec.md
+++ b/docs/modules/control-clpxp/spec.md
@@ -14,7 +14,7 @@ The ClpXP control Module uses the ClpXP protease complex to enable the programma
 
 This Module has not been validated in Nucleus Cytosol $\ge$ v0.5. Documentation can be found on our legacy site [here](https://nucleus.bnext.bio/ClpXP-Control-Module-2dcae616eb51805d882cea7a610ff38e) and in the following DevNotes:
 
-- [ClpXP Module Validation in Cells](https://devnotes.nucleus.engineering/articles/bnext-devnotes-clpxp-cells-01)
-- [ClpXP Module Validation in Cytosol](https://devnotes.nucleus.engineering/articles/bnext-devnotes-clpxp-cytosol-01)
+- [ClpXP Module Validation in Cells](https://devnotes.nucleus.engineering/articles/bnext-devnotes-clpxp-pure-cells-01)
+- [ClpXP Module Validation in PURE](https://devnotes.nucleus.engineering/articles/bnext-devnotes-clpx-in-pure-01)
 
 :::

--- a/docs/processes/assemble-base-cytosol/main.md
+++ b/docs/processes/assemble-base-cytosol/main.md
@@ -47,9 +47,9 @@ Please read this section carefully. It contains important notes, resources, and 
 :label: tbl:critical-materials
 :align: center
 
-| Name | Type | Specification |
-| --- | --- | --- |
-| `pOpen-deGFP` | Reporter | [pOpen-GFP]() |
+| Name          | Type     | Specification                                       |
+| ------------- | -------- | --------------------------------------------------- |
+| `pOpen-deGFP` | Reporter | [pOpen-deGFP](/docs/modules/reporter-degfp/spec.md) |
 :::
 
 ::::::

--- a/docs/processes/make-1pot/main.md
+++ b/docs/processes/make-1pot/main.md
@@ -5,7 +5,7 @@ subtitle: "Process"
 
 # Overview
 
-Making PURE requires making Protein Mix, which contains the thirty-six (36) proteins in the PURE system. If you want to purify each protein individually, you can follow our [36-pot protocol](../make-36pot/main.md). However, if you want working protein mix with less time and effort, you can co-express and co-purify all 36 proteins at once in OnePot. This protocol shows you how. This protocol has been established to grow, purify, and characterize OnePot PURE proteins following [Lavickova’s OnePot PURE protocol](10.3791/62625) with a few deviations. 
+Making PURE requires making Protein Mix, which contains the thirty-six (36) proteins in the PURE system. If you want to purify each protein individually, you can follow our [36-pot protocol](../make-36pot/main.md). However, if you want working protein mix with less time and effort, you can co-express and co-purify all 36 proteins at once in OnePot. This protocol shows you how. This protocol has been established to grow, purify, and characterize OnePot PURE proteins following [Lavickova’s OnePot PURE protocol](https://doi.org/10.3791/62625) with a few deviations. 
 
 :::{attention}
 This Process has not yet been migrated onto Nucleus Documentation. The protocol can be found on our legacy site [here](https://nucleus.bnext.bio/Make-OnePot-Protein-Mix-234ae616eb5180c0b84cf5046d63a803).

--- a/docs/processes/make-small-molecule-mix/main.md
+++ b/docs/processes/make-small-molecule-mix/main.md
@@ -29,9 +29,9 @@ Please read this section carefully. It contains important notes, resources, and 
 :label: tbl:critical-materials
 :align: center
 
-| **Reagent** | **Product Name** | **Manufacturer** | **Part #** | **Price** | Storage Conditions | **Link** |
-| --- | --- | --- | --- | --- | --- | --- |
-| Folinic acid | Folinic acid calcium salt hydrate | Sigma-Aldrich | F7878-100MG | $108 | 4C to 30C | [[link](https://www.sigmaaldrich.com/US/en/product/sial/f7878)] |
+| **Reagent**  | **Product Name**                  | **Manufacturer** | **Part #**  | **Price** | Storage Conditions | **Link**                                                        |
+| ------------ | --------------------------------- | ---------------- | ----------- | --------- | ------------------ | --------------------------------------------------------------- |
+| Folinic acid | Folinic acid calcium salt hydrate | Sigma-Aldrich    | F7878-100MG | $108      | 4C to 30C          | [[link](https://www.sigmaaldrich.com/US/en/product/sial/f7878)] |
 
 :::
 
@@ -80,16 +80,16 @@ Please read this section carefully. It contains important notes, resources, and 
 :label: tbl:stock-solutions
 :align: center
 
-| Reagent                     | **MW (g/mol)** | **Amount (g)** | **Final Volume (mL)**                                  | **Storage**     | **Needs pH adjustment?** | **Needs Sterilization?** |
-| --------------------------- | -------------- | -------------- | ------------------------------------------------------ | --------------- | ------------------------ | ------------------------ |
-| Potassium Hydroxide (1 M)   | 56.11          | 14.0           | 250                                                    | 4C to 30C       | no                       | no                       |
-| HEPES-KOH (pH 7.6, 1 M)     | 238.3          | 59.5           | 250                                                    | 4C to 30C; dark | yes                      | no                       |
-| Potassium glutamate (2.5 M) | 203.23         | 21.8           | 50                                                     | 4C to 30C       | no                       | no                       |
-| Magnesium acetate (1 M)     | 214.45         | 10.8           | 50                                                     | 4C to 30C       | no                       | no                       |
-| Creatine phosphate (500 mM) | 327.14         | 1              | 9.43                                                   | -25C to -15C    | no                       | no                       |
-| Folinic acid (5 mM)         | 511.50         | See above      |                                                        | -25C to -15C    | no                       | no                       |
-| Spermidine (500 mM)         | 145.25         | 1              | 13.77                                                  | -25C to -15C    | no                       | no                       |
-| Amino Acid Mix              |                |                | see [Make Amino Acid Mix](../make-amino-acid-mix/main) | -85C to -15C    | yes                      | yes                      |
+| Reagent                     | **MW (g/mol)** | **Amount (g)** | **Final Volume (mL)**                                     | **Storage**     | **Needs pH adjustment?** | **Needs Sterilization?** |
+| --------------------------- | -------------- | -------------- | --------------------------------------------------------- | --------------- | ------------------------ | ------------------------ |
+| Potassium Hydroxide (1 M)   | 56.11          | 14.0           | 250                                                       | 4C to 30C       | no                       | no                       |
+| HEPES-KOH (pH 7.6, 1 M)     | 238.3          | 59.5           | 250                                                       | 4C to 30C; dark | yes                      | no                       |
+| Potassium glutamate (2.5 M) | 203.23         | 21.8           | 50                                                        | 4C to 30C       | no                       | no                       |
+| Magnesium acetate (1 M)     | 214.45         | 10.8           | 50                                                        | 4C to 30C       | no                       | no                       |
+| Creatine phosphate (500 mM) | 327.14         | 1              | 9.43                                                      | -25C to -15C    | no                       | no                       |
+| Folinic acid (5 mM)         | 511.50         | See above      |                                                           | -25C to -15C    | no                       | no                       |
+| Spermidine (500 mM)         | 145.25         | 1              | 13.77                                                     | -25C to -15C    | no                       | no                       |
+| Amino Acid Mix              |                |                | see [Make Amino Acid Mix](../make-amino-acid-mix/main.md) | -85C to -15C    | yes                      | yes                      |
 
 :::
 

--- a/docs/processes/make-small-molecule-mix/main.md
+++ b/docs/processes/make-small-molecule-mix/main.md
@@ -80,16 +80,16 @@ Please read this section carefully. It contains important notes, resources, and 
 :label: tbl:stock-solutions
 :align: center
 
-| Reagent | **MW (g/mol)** | **Amount (g)** | **Final Volume (mL)** | **Storage** | **Needs pH adjustment?** | **Needs Sterilization?** |
-| --- | --- | --- | --- | --- | --- | --- |
-| Potassium Hydroxide (1 M) | 56.11 | 14.0 | 250 | 4C to 30C | no | no |
-| HEPES-KOH (pH 7.6, 1 M) | 238.3 | 59.5 | 250 | 4C to 30C; dark | yes | no |
-| Potassium glutamate (2.5 M) | 203.23 | 21.8 | 50 | 4C to 30C | no | no |
-| Magnesium acetate (1 M) | 214.45 | 10.8 | 50 | 4C to 30C | no | no |
-| Creatine phosphate (500 mM) | 327.14 | 1 | 9.43 | -25C to -15C | no | no |
-| Folinic acid (5 mM) | 511.50 | See above  |  | -25C to -15C | no | no |
-| Spermidine (500 mM) | 145.25 | 1 | 13.77 | -25C to -15C | no | no |
-| Amino Acid Mix |  |  | see [Make Amino Acid Mix](../make-amino-acid-mix/process-Make_Amino_Acid_Mix.md)  | -85C to -15C | yes | yes |
+| Reagent                     | **MW (g/mol)** | **Amount (g)** | **Final Volume (mL)**                                  | **Storage**     | **Needs pH adjustment?** | **Needs Sterilization?** |
+| --------------------------- | -------------- | -------------- | ------------------------------------------------------ | --------------- | ------------------------ | ------------------------ |
+| Potassium Hydroxide (1 M)   | 56.11          | 14.0           | 250                                                    | 4C to 30C       | no                       | no                       |
+| HEPES-KOH (pH 7.6, 1 M)     | 238.3          | 59.5           | 250                                                    | 4C to 30C; dark | yes                      | no                       |
+| Potassium glutamate (2.5 M) | 203.23         | 21.8           | 50                                                     | 4C to 30C       | no                       | no                       |
+| Magnesium acetate (1 M)     | 214.45         | 10.8           | 50                                                     | 4C to 30C       | no                       | no                       |
+| Creatine phosphate (500 mM) | 327.14         | 1              | 9.43                                                   | -25C to -15C    | no                       | no                       |
+| Folinic acid (5 mM)         | 511.50         | See above      |                                                        | -25C to -15C    | no                       | no                       |
+| Spermidine (500 mM)         | 145.25         | 1              | 13.77                                                  | -25C to -15C    | no                       | no                       |
+| Amino Acid Mix              |                |                | see [Make Amino Acid Mix](../make-amino-acid-mix/main) | -85C to -15C    | yes                      | yes                      |
 
 :::
 

--- a/docs/processes/make-small-molecule-mix/protocol-make_small_molecule_mix.md
+++ b/docs/processes/make-small-molecule-mix/protocol-make_small_molecule_mix.md
@@ -20,16 +20,16 @@ exports:
 :label: tbl:stock-solutions
 :align: center
 
-| Reagent                     | **MW (g/mol)** | **Amount (g)** | **Final Volume (mL)**                 | **Storage**     | **Needs pH adjustment?** | **Needs Sterilization?** |
-| --------------------------- | -------------- | -------------- | ------------------------------------- | --------------- | ------------------------ | ------------------------ |
-| Potassium Hydroxide (1 M)   | 56.11          | 14.0           | 250                                   | 4C to 30C       | no                       | no                       |
-| HEPES-KOH (pH 7.6, 1 M)     | 238.3          | 59.5           | 250                                   | 4C to 30C; dark | yes                      | no                       |
-| Potassium glutamate (2.5 M) | 203.23         | 21.8           | 50                                    | 4C to 30C       | no                       | no                       |
-| Magnesium acetate (1 M)     | 214.45         | 10.8           | 50                                    | 4C to 30C       | no                       | no                       |
-| Creatine phosphate (500 mM) | 327.14         | 1              | 9.43                                  | -25C to -15C    | no                       | no                       |
-| Folinic acid (5 mM)         | 511.50         | See above      |                                       | -25C to -15C    | no                       | no                       |
-| Spermidine (500 mM)         | 145.25         | 1              | 13.77                                 | -25C to -15C    | no                       | no                       |
-| Amino Acid Mix              |                |                | see [Make Amino Acid Mix](../main.md) | -85C to -15C    | yes                      | yes                      |
+| Reagent                     | **MW (g/mol)** | **Amount (g)** | **Final Volume (mL)**                                     | **Storage**     | **Needs pH adjustment?** | **Needs Sterilization?** |
+| --------------------------- | -------------- | -------------- | --------------------------------------------------------- | --------------- | ------------------------ | ------------------------ |
+| Potassium Hydroxide (1 M)   | 56.11          | 14.0           | 250                                                       | 4C to 30C       | no                       | no                       |
+| HEPES-KOH (pH 7.6, 1 M)     | 238.3          | 59.5           | 250                                                       | 4C to 30C; dark | yes                      | no                       |
+| Potassium glutamate (2.5 M) | 203.23         | 21.8           | 50                                                        | 4C to 30C       | no                       | no                       |
+| Magnesium acetate (1 M)     | 214.45         | 10.8           | 50                                                        | 4C to 30C       | no                       | no                       |
+| Creatine phosphate (500 mM) | 327.14         | 1              | 9.43                                                      | -25C to -15C    | no                       | no                       |
+| Folinic acid (5 mM)         | 511.50         | See above      |                                                           | -25C to -15C    | no                       | no                       |
+| Spermidine (500 mM)         | 145.25         | 1              | 13.77                                                     | -25C to -15C    | no                       | no                       |
+| Amino Acid Mix              |                |                | see [Make Amino Acid Mix](../make-amino-acid-mix/main.md) | -85C to -15C    | yes                      | yes                      |
 
 :::
 

--- a/docs/processes/make-small-molecule-mix/protocol-make_small_molecule_mix.md
+++ b/docs/processes/make-small-molecule-mix/protocol-make_small_molecule_mix.md
@@ -20,16 +20,16 @@ exports:
 :label: tbl:stock-solutions
 :align: center
 
-| Reagent | **MW (g/mol)** | **Amount (g)** | **Final Volume (mL)** | **Storage** | **Needs pH adjustment?** | **Needs Sterilization?** |
-| --- | --- | --- | --- | --- | --- | --- |
-| Potassium Hydroxide (1 M) | 56.11 | 14.0 | 250 | 4C to 30C | no | no |
-| HEPES-KOH (pH 7.6, 1 M) | 238.3 | 59.5 | 250 | 4C to 30C; dark | yes | no |
-| Potassium glutamate (2.5 M) | 203.23 | 21.8 | 50 | 4C to 30C | no | no |
-| Magnesium acetate (1 M) | 214.45 | 10.8 | 50 | 4C to 30C | no | no |
-| Creatine phosphate (500 mM) | 327.14 | 1 | 9.43 | -25C to -15C | no | no |
-| Folinic acid (5 mM) | 511.50 | See above  |  | -25C to -15C | no | no |
-| Spermidine (500 mM) | 145.25 | 1 | 13.77 | -25C to -15C | no | no |
-| Amino Acid Mix |  |  | see [Make Amino Acid Mix](../make-amino-acid-mix/process-Make_Amino_Acid_Mix.md)  | -85C to -15C | yes | yes |
+| Reagent                     | **MW (g/mol)** | **Amount (g)** | **Final Volume (mL)**                 | **Storage**     | **Needs pH adjustment?** | **Needs Sterilization?** |
+| --------------------------- | -------------- | -------------- | ------------------------------------- | --------------- | ------------------------ | ------------------------ |
+| Potassium Hydroxide (1 M)   | 56.11          | 14.0           | 250                                   | 4C to 30C       | no                       | no                       |
+| HEPES-KOH (pH 7.6, 1 M)     | 238.3          | 59.5           | 250                                   | 4C to 30C; dark | yes                      | no                       |
+| Potassium glutamate (2.5 M) | 203.23         | 21.8           | 50                                    | 4C to 30C       | no                       | no                       |
+| Magnesium acetate (1 M)     | 214.45         | 10.8           | 50                                    | 4C to 30C       | no                       | no                       |
+| Creatine phosphate (500 mM) | 327.14         | 1              | 9.43                                  | -25C to -15C    | no                       | no                       |
+| Folinic acid (5 mM)         | 511.50         | See above      |                                       | -25C to -15C    | no                       | no                       |
+| Spermidine (500 mM)         | 145.25         | 1              | 13.77                                 | -25C to -15C    | no                       | no                       |
+| Amino Acid Mix              |                |                | see [Make Amino Acid Mix](../main.md) | -85C to -15C    | yes                      | yes                      |
 
 :::
 


### PR DESCRIPTION
Fixes all dead links identified in issue #33 during the lychee link-checking spike.

## Changes

- **`make-small-molecule-mix/main.md` and `protocol-make_small_molecule_mix.md`** — internal links to amino acid mix page were leftover Notion export filenames; corrected to `../make-amino-acid-mix/main.md`
- **`control-clpxp/spec.md`** — two DevNote URLs had wrong slugs (referenced cytosol when the notes are about PURE); corrected to the right article paths
- **`assemble-base-cytosol/main.md`** — empty URL on `pOpen-deGFP` link filled in; typo fixed
- **`make-1pot/main.md`** — bare DOI `10.3791/62625` wrapped as `https://doi.org/10.3791/62625`

## Verification

Ran `lychee --config .lychee.toml docs/` after fixes — 0 errors on all previously broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)