### PR TITLE
Add lychee link checker (closes #7)

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,19 @@
+name: Check Links
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install lychee
+        run: |
+          curl -sS https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz \
+            | tar xz -C /usr/local/bin lychee
+
+      - name: Check links
+        run: python3 scripts/check-links.py docs/

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install lychee
         run: |
           curl -sSL https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz \
-            | tar xz -C /usr/local/bin lychee
+            | tar xz --strip-components=1 -C /usr/local/bin lychee-x86_64-unknown-linux-gnu/lychee
 
       - name: Check links
         run: python3 scripts/check-links.py docs/

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -12,7 +12,7 @@ jobs:
 
       - name: Install lychee
         run: |
-          curl -sS https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz \
+          curl -sSL https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz \
             | tar xz -C /usr/local/bin lychee
 
       - name: Check links

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,30 @@
+# .lychee.toml — lychee link checker configuration
+# Run locally: lychee docs/
+# See: https://lychee.cli.rs/
+
+# Accepted HTTP status codes.
+# Explicitly restates the lychee default (100..=103, 200..=299) plus 403.
+# 403 is expected for academic papers and some vendor pages behind paywalls —
+# a 403 on a DOI or journal link does not mean the link is broken.
+accept = ["100..=103", "200..=299", "403"]
+
+# Root directory for resolving root-relative links (e.g. /docs/modules/foo/spec.md).
+# MyST supports root-relative paths as valid cross-page links; without this,
+# lychee treats them as unresolvable and flags them as errors.
+# Run lychee from the repo root for this to work correctly.
+root_dir = "."
+
+# Vendor sites that block automated crawlers with HTTP/2 errors or
+# bot-detection responses. These URLs are valid; lychee just can't check them.
+exclude = [
+  'sigmaaldrich\.com',
+]
+
+# Request timeout in seconds
+timeout = 20
+
+# Maximum number of redirects to follow
+max_redirects = 10
+
+# Skip mailto: links
+include_mail = false

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -14,11 +14,9 @@ accept = ["100..=103", "200..=299", "403"]
 # Run lychee from the repo root for this to work correctly.
 root_dir = "."
 
-# Vendor sites that block automated crawlers with HTTP/2 errors or
-# bot-detection responses. These URLs are valid; lychee just can't check them.
-exclude = [
-  'sigmaaldrich\.com',
-]
+# Note: sigmaaldrich.com terminates HTTP/2 connections at the protocol level,
+# returning no HTTP status code. check-links.py filters these out specifically
+# so genuine dead Sigma links (DNS failure, 404, etc.) are still caught.
 
 # Request timeout in seconds
 timeout = 20

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,19 @@ Vale rules live in `styles/nucleus/`. Current rules enforce temperature unit for
 
 Do not add Vale inline suppression comments (`<!-- vale off -->`) without confirming with the developer first.
 
+### Link checking (lychee)
+
+**Run `python3 scripts/check-links.py docs/` before opening a PR if you have added, edited, or removed any links or URLs.** This is slower than Vale and doesn't need to run on every commit — focus on PRs that touch links.
+
+```bash
+python3 scripts/check-links.py docs/       # check all docs
+python3 scripts/check-links.py <file.md>   # check a single file
+```
+
+The script wraps `lychee` and filters known false positives before reporting. **What it catches:** dead internal links, 404 external links, empty URLs. **What it does not catch:** product catalog changes on vendor sites (e.g. Sigma-Aldrich discontinuing a part number) — those require manual review.
+
+**Interpreting output.** The script will note how many HTTP/2 false positives were filtered from `sigmaaldrich.com` — these are valid URLs on a server that blocks automated crawlers at the protocol level and can be ignored. Any remaining errors are genuine and should be fixed before opening a PR.
+
 ### Pull request workflow
 
 When merging a PR via `gh pr merge`, never use `--admin` to bypass branch protection rules. If a merge fails due to branch policy, stop and ask the developer how to proceed — options are leaving the PR open for a reviewer, asking the developer to approve it themselves, or using `--auto` to merge once requirements are met.

--- a/scripts/check-links.py
+++ b/scripts/check-links.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+check-links.py — lychee wrapper that filters known vendor HTTP/2 false positives.
+
+Some vendor sites (e.g. sigmaaldrich.com) terminate HTTP/2 connections at the
+protocol level before returning any HTTP status code. This produces a
+"Network error: HTTP/2 protocol error" in lychee's output that cannot be
+distinguished from a real error via lychee config alone.
+
+This script runs lychee with JSON output, filters out errors that match the
+known HTTP/2 false-positive pattern for excluded domains, and exits non-zero
+only if genuine errors remain.
+
+Usage:
+    python3 scripts/check-links.py [lychee args...]
+    python3 scripts/check-links.py docs/
+    python3 scripts/check-links.py --no-progress docs/
+"""
+
+import json
+import subprocess
+import sys
+
+# Domains that kill HTTP/2 connections at the protocol level.
+# These are not dead links — they are valid URLs on servers that block crawlers.
+# Any other error type from these domains (404, DNS failure, etc.) will still
+# be reported as a genuine error.
+HTTP2_FALSE_POSITIVE_DOMAINS = [
+    "sigmaaldrich.com",
+]
+
+HTTP2_ERROR_SUBSTRING = "HTTP/2 protocol error"
+
+
+def is_http2_false_positive(url: str, error_text: str) -> bool:
+    return (
+        any(domain in url for domain in HTTP2_FALSE_POSITIVE_DOMAINS)
+        and HTTP2_ERROR_SUBSTRING in error_text
+    )
+
+
+def main():
+    args = sys.argv[1:] or ["docs/"]
+
+    result = subprocess.run(
+        ["lychee", "--config", ".lychee.toml", "--format", "json", "--no-progress", *args],
+        capture_output=True,
+        text=True,
+    )
+
+    # lychee emits a trailing "Hint:" line after the JSON — strip it
+    json_text = result.stdout.split("\nHint:")[0].strip()
+
+    try:
+        report = json.loads(json_text)
+    except json.JSONDecodeError:
+        print("ERROR: could not parse lychee JSON output:")
+        print(result.stdout)
+        sys.exit(1)
+
+    # Filter error_map: remove known HTTP/2 false positives
+    genuine_errors = {}
+    filtered_count = 0
+
+    for filepath, entries in report.get("error_map", {}).items():
+        real = []
+        for entry in entries:
+            url = entry.get("url", "")
+            text = entry.get("status", {}).get("text", "")
+            if is_http2_false_positive(url, text):
+                filtered_count += 1
+            else:
+                real.append(entry)
+        if real:
+            genuine_errors[filepath] = real
+
+    # Print summary
+    total_errors = sum(len(v) for v in genuine_errors.values())
+    excludes = report.get("excludes", 0)
+    successful = report.get("successful", 0)
+    total = report.get("total", 0)
+
+    if filtered_count:
+        print(f"ℹ️  Filtered {filtered_count} HTTP/2 false positive(s) from {', '.join(HTTP2_FALSE_POSITIVE_DOMAINS)}")
+
+    if genuine_errors:
+        print(f"\n❌ {total_errors} genuine error(s) found:\n")
+        for filepath, entries in genuine_errors.items():
+            print(f"  {filepath}")
+            for entry in entries:
+                url = entry.get("url", "")
+                details = entry.get("status", {}).get("details", "")
+                line = entry.get("span", {}).get("line", "?")
+                print(f"    [{line}] {url} — {details}")
+        sys.exit(1)
+    else:
+        print(f"✅ {successful}/{total} links OK ({excludes} excluded)")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-links.py
+++ b/scripts/check-links.py
@@ -18,6 +18,7 @@ Usage:
 """
 
 import json
+import shutil
 import subprocess
 import sys
 
@@ -40,6 +41,10 @@ def is_http2_false_positive(url: str, error_text: str) -> bool:
 
 
 def main():
+    if not shutil.which("lychee"):
+        print("ERROR: lychee is not installed. Run ./setup.sh or: brew install lychee")
+        sys.exit(1)
+
     args = sys.argv[1:] or ["docs/"]
 
     result = subprocess.run(
@@ -89,7 +94,8 @@ def main():
             print(f"  {filepath}")
             for entry in entries:
                 url = entry.get("url", "")
-                details = entry.get("status", {}).get("details", "")
+                status = entry.get("status", {})
+                details = status.get("details", "") or status.get("text", "")
                 line = entry.get("span", {}).get("line", "?")
                 print(f"    [{line}] {url} — {details}")
         sys.exit(1)

--- a/setup.sh
+++ b/setup.sh
@@ -11,6 +11,11 @@ if ! command -v vale &> /dev/null; then
   brew install vale
 fi
 
+# Install lychee if not already present
+if ! command -v lychee &> /dev/null; then
+  brew install lychee
+fi
+
 conda env remove -n nucleus-docs 2>/dev/null
 conda env create -f environment.yml
 echo ""


### PR DESCRIPTION
Implements automated link checking via lychee, closing issue #7.

## What's included

- **`.lychee.toml`** — lychee configuration: accepts 403 (paywalled content), sets `root_dir` to resolve MyST root-relative links, configures timeout/redirects
- **`scripts/check-links.py`** — thin wrapper around `lychee --format json` that filters HTTP/2 false positives from `sigmaaldrich.com` (their server kills crawler connections at the protocol level before returning any status code) while still surfacing genuine errors from that domain
- **`.github/workflows/check-links.yml`** — CI workflow that runs on every PR targeting `main`
- **`setup.sh`** — installs lychee via brew alongside Vale on first-time setup
- **`CLAUDE.md`** — pre-PR checklist guidance and output interpretation notes

## Design decisions

- **403 accepted** — expected for academic papers behind journal paywalls; a 403 on a DOI is not a broken link
- **Sigma-Aldrich filtered in script, not excluded in config** — so genuine dead Sigma links (404, DNS failure) are still caught; only the known HTTP/2 protocol-level termination is suppressed
- **`root_dir = "."`** — required for MyST root-relative links like `/docs/modules/foo/spec.md` which are valid site paths but unresolvable by lychee without a root

## Local usage

```bash
python3 scripts/check-links.py docs/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)