### PR TITLE
fix: broaden gitignore to cover all Notion 'Private & Shared*' variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,5 @@ dep/
 # Notion export artifacts (raw exports, zips, staging dirs)
 **/resources/*.zip
 **/resources/notion_export/
-**/resources/Private & Shared/
+**/resources/Private & Shared*/
 **/resources/*-notion.md


### PR DESCRIPTION
Notion exports can produce numbered variants like 'Private & Shared 2/' and 'Private & Shared 3/' depending on export history. The previous pattern only matched the exact name 'Private & Shared/'.