### PR TITLE
feat(dna-links): update module Designs tables to link nucleus-eng/DNA repo

### DIFF
--- a/docs/dna-distro.md
+++ b/docs/dna-distro.md
@@ -9,3 +9,5 @@ The Nucleus DNA Distribution consists of OpenMTA genetic constructs that can be 
 The documentation for DNA Distribution can be found on the legacy site [here](https://nucleus.bnext.bio/DNA-Distribution-6d3e45ae88b84a038828b815ed54e8bc). 
 
 :::
+
+Sequence files for all Nucleus Distribution constructs are maintained in the [nucleus-eng/DNA](https://github.com/nucleus-eng/DNA) repository on GitHub. Files are in GenBank (`.gb`) format and can be opened in Benchling, SnapGene, or any GenBank-compatible sequence editor.

--- a/docs/modules/detector-tetr_atc/spec.md
+++ b/docs/modules/detector-tetr_atc/spec.md
@@ -24,8 +24,8 @@ Schematic of the TetR inducible expression module. TetR represses expression fro
 ::::{tab-item} Designs
 | **Name** | **Length (bp)** | **File** |
 | --- | --- | --- |
-| `pT7-tetR` | N/A | Nucleus v0.1.0 Distribution Plate, well G1 |
-| `pT7-tetO-plamGFP` | N/A | Nucleus v0.1.0 Distribution Plate, well G3 |
+| `pT7-tetR` | 2877 | [pOpen-tetR.gb](https://github.com/nucleus-eng/DNA/blob/main/detectors/pOpen-tetR.gb) |
+| `pT7-tetO-plamGFP` | 2954 | [pOpen-pT7-tetO.gb](https://github.com/nucleus-eng/DNA/blob/main/detectors/pOpen-pT7-tetO.gb) |
 ::::
 
 :::::

--- a/docs/modules/emitter-ivhsl/spec.md
+++ b/docs/modules/emitter-ivhsl/spec.md
@@ -24,8 +24,8 @@ Design schematic of the IV-HSL Emitter module. `pT7-bjaI` expresses the BjaI enz
 ::::{tab-item} Designs
 | **Name** | **Length (bp)** | **File** |
 | --- | --- | --- |
-| `pT7-bjaI` | N/A | Nucleus v0.3.0 Distribution Plate *(upcoming)* |
-| `bjaR-GFP-native` | N/A | Nucleus v0.3.0 Distribution Plate *(upcoming)* |
+| `pOpen-pT7-bjaI` | 2752 | [pOpen-pT7-bjaI.gb](https://github.com/nucleus-eng/DNA/blob/main/detectors/quorum-sensing/pOpen-pT7-bjaI.gb) |
+| `pOpen-bjaR-GFP-native` | 3877 | [pOpen-bjaR-GFP-native.gb](https://github.com/nucleus-eng/DNA/blob/main/detectors/quorum-sensing/pOpen-bjaR-GFP-native.gb) |
 ::::
 
 :::::


### PR DESCRIPTION
Partially addresses #47 (still open)

## Changes

- **`detector-tetr_atc/spec.md`**: Link `pT7-tetR` → [`pOpen-tetR.gb`](https://github.com/nucleus-eng/DNA/blob/main/detectors/pOpen-tetR.gb) and `pT7-tetO-plamGFP` → [`pOpen-pT7-tetO.gb`](https://github.com/nucleus-eng/DNA/blob/main/detectors/pOpen-pT7-tetO.gb); fill in actual bp lengths (2877, 2954)
- **`emitter-ivhsl/spec.md`**: Link [`pOpen-pT7-bjaI.gb`](https://github.com/nucleus-eng/DNA/blob/main/detectors/quorum-sensing/pOpen-pT7-bjaI.gb) and [`pOpen-bjaR-GFP-native.gb`](https://github.com/nucleus-eng/DNA/blob/main/detectors/quorum-sensing/pOpen-bjaR-GFP-native.gb); update construct names to `pOpen-`-prefixed form to match filenames; fill in actual bp lengths (2752, 3877)
- **`dna-distro.md`**: Add GitHub repo link alongside existing legacy site reference

## Not yet updated (sequences missing from DNA repo)

- `reporter-degfp` — `pOpen-deGFP.gb` not yet in repo → tracked in nucleus-eng/DNA#2
- `control-clpxp` — `pT7-ClpX`, `pT7-ClpP`, `pT7-deGFP-ssrA` not yet in repo → tracked in nucleus-eng/DNA#3

🤖 Generated with [Claude Code](https://claude.com/claude-code)