### PR TITLE
feat(vale): add nucleus.unit-spacing rule; fix 12 violations in make-trna

### DIFF
--- a/docs/processes/make-trna/main.md
+++ b/docs/processes/make-trna/main.md
@@ -176,7 +176,7 @@ From our experience, a good rule of thumb is to target a final volume around 100
 - [ ] Estimate your yield by A260 ([tRNA] = A260 * 40 mg/mL). Typical yield of tRNA is typically between (4-20) mg per gram of cell mass.
 - [ ] Estimate your purity by A260/A230 and A260/A280 (both should be ≥1.8).
 
-:::{tip} Note: [tRNA] = A260 * 40 mg / mL
+:::{tip} Note: [tRNA] = A260 * 40 mg/mL
 :class: dropdown
 A260 units (*a.k.a.* “absorbance units”, or “A260”) are defined as the amount of light (wavelength = 260 nm) absorbed as it passes through 1 cm of the sample being measured. 
 
@@ -193,11 +193,11 @@ NEB has a great [tool](https://nebiocalculator.neb.com/#!/od260) for converting 
     - [ ] Pre-run gels at 100 V / 30 min.
     - [ ] Wash wells with running buffer by syringe. You should be able to see urea displaced from the well by change in refractive index.
 - [ ]  Prepare tRNA samples:
-    - [ ] Dilute tRNAs to 40 ng / µL tRNA in nuclase-free water.
-    - [ ] Prepare 20 ng / µL sample by adding 10 µL of 40 ng / µL tRNA to 10 µL 2x TBE-Urea sample buffer.
+    - [ ] Dilute tRNAs to 40 ng/µL tRNA in nuclase-free water.
+    - [ ] Prepare 20 ng/µL sample by adding 10 µL of 40 ng/µL tRNA to 10 µL 2x TBE-Urea sample buffer.
     - [ ] Prepare an ssRNA ladder. We use the NEB low range ssRNA (2 µL ladder + 2 µL 2x sample buffer).
     - [ ] Incubate sample and and ladder at 65°C / 3 min → 4°C / hold using a thermal cycler.
-- [ ] Load 200 ng of tRNA (10 µL at 20 ng / µL) onto the TBE-Urea gel and run at 125V / 2.5 hr.
+- [ ] Load 200 ng of tRNA (10 µL at 20 ng/µL) onto the TBE-Urea gel and run at 125V / 2.5 hr.
 - [ ] Meanwhile, prepare SYBR-Green stain (4 µL in 40 mL water) to stain gel.
 - [ ] Soak gel in SYBR-Green stain and visualize gel using UV or blue-light transilluminator. You should see multiple distinct bands around 75-90 nt.
 
@@ -209,7 +209,7 @@ If your samples appear as a smear on your gel, consider testing your input buffe
 :::
 ## Formulation
 
-- [ ] Dilute your tRNA stocks in nuclease-free water to 35 µg / µL, which is 10x working concentration for cytosol reactions. 
+- [ ] Dilute your tRNA stocks in nuclease-free water to 35 µg/µL, which is 10x working concentration for cytosol reactions. 
 
 ## Storage
 

--- a/docs/processes/make-trna/protocol.md
+++ b/docs/processes/make-trna/protocol.md
@@ -116,11 +116,11 @@ exports:
         - [ ]  Pre-run gels at 100 V / 30 min.
         - [ ]  Wash wells with running buffer by syringe. You should be able to see urea displaced from the well by change in refractive index.
     - [ ]  Prepare tRNA samples:
-        - [ ]  Dilute tRNAs to 40 ng / µL tRNA in nuclease-free water.
-        - [ ]  Prepare 20 ng / µL sample by adding 10 µL of 40 ng / µL tRNA to 10 µL 2x TBE-Urea sample buffer.
+        - [ ]  Dilute tRNAs to 40 ng/µL tRNA in nuclease-free water.
+        - [ ]  Prepare 20 ng/µL sample by adding 10 µL of 40 ng/µL tRNA to 10 µL 2x TBE-Urea sample buffer.
         - [ ]  Prepare an ssRNA ladder. We use the NEB low range ssRNA (2 µL ladder + 2 µL 2x sample buffer).
         - [ ]  Incubate sample and and ladder at 65°C / 3 min → 4°C / hold using a thermal cycler.
-    - [ ]  Load 200 ng of tRNA (10 µL at 20 ng / µL) onto the TBE-Urea gel and run at 125V / 2.5 hr.
+    - [ ]  Load 200 ng of tRNA (10 µL at 20 ng/µL) onto the TBE-Urea gel and run at 125V / 2.5 hr.
     - [ ]  Meanwhile, prepare SYBR-Green stain (4 µL in 40 mL water) to stain gel.
     - [ ]  Soak gel in SYBR-Green stain and visualize gel using UV or blue-light transilluminator. You should see multiple distinct bands around 75-90 nt.
 
@@ -130,7 +130,7 @@ exports:
 
 ## Formulation
 
-- [ ] Dilute your tRNA stocks in nuclease-free water to your working concentration, depending on your application. We recommend 50 µg / µL to use as a component in Energy Mix, or 35 µg / µL as a 10x stock for PUREΔtRNA reactions (add 1 µL to 10 µL reactions).
+- [ ] Dilute your tRNA stocks in nuclease-free water to your working concentration, depending on your application. We recommend 50 µg/µL to use as a component in Energy Mix, or 35 µg/µL as a 10x stock for PUREΔtRNA reactions (add 1 µL to 10 µL reactions).
 
 ## Storage
 

--- a/styles/nucleus/unit-spacing.yml
+++ b/styles/nucleus/unit-spacing.yml
@@ -1,0 +1,5 @@
+extends: existence
+message: "Remove spaces around '/' in compound unit expressions: '%s' should use no spaces (e.g., 'ng/µL', 'mg/mL')."
+level: error
+raw:
+  - '\b(?:n|µ|m|p|f|k)?[gLM]\s+/\s+(?:n|µ|m|p|f|k)?[gLM]\b'

--- a/styles/tests/unit-spacing.md
+++ b/styles/tests/unit-spacing.md
@@ -1,0 +1,25 @@
+# Unit Spacing Test
+
+## Should fire (spaces around '/' in compound unit expressions)
+
+Dilute tRNAs to 40 ng / µL in nuclease-free water.
+Prepare a 20 ng / µL sample from stock.
+Dilute to 35 µg / µL as a 10x working stock.
+The conversion factor is 40 mg / mL per A260 unit.
+Add substrate at 10 µM / mL to the reaction.
+Stock concentration is 100 ng / mL.
+
+## Should NOT fire (correct — no spaces around '/')
+
+Dilute tRNAs to 40 ng/µL in nuclease-free water.
+Prepare a 20 ng/µL sample from stock.
+Dilute to 35 µg/µL as a 10x working stock.
+The conversion factor is 40 mg/mL per A260 unit.
+
+## Should NOT fire (non-unit expressions with '/')
+
+Pre-run gels at 100 V / 30 min.
+Run the gel at 125V / 2.5 hr.
+Incubate at 65°C / 3 min then hold at 4°C.
+See Figure 2 / Panel B for details.
+Mix at a ratio of 1 / 10 dilution.


### PR DESCRIPTION
Closes #32

## Changes

### New rule: `styles/nucleus/unit-spacing.yml`
Flags spaces around `/` in compound unit expressions. Pattern: `\b(?:n|µ|m|p|f|k)?[gLM]\s+/\s+(?:n|µ|m|p|f|k)?[gLM]\b`. Does not fire on non-unit expressions like `100 V / 30 min` or `65°C / 3 min`.

### New test fixture: `styles/tests/unit-spacing.md`
6 should-fire cases, 9 should-not-fire cases (4 correct forms, 5 non-unit `/` expressions). Verified: all 6 fire, 0 false positives.

### Fixes in `docs/processes/make-trna/`
All 12 pre-existing violations corrected:
- `main.md`: `mg / mL` (×1), `ng / µL` (×4), `µg / µL` (×1)
- `protocol.md`: `ng / µL` (×4), `µg / µL` (×2)

`vale docs/` exits clean on `nucleus.unit-spacing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)