### PR TITLE
docs(dna-distro): restructure DNA Distribution page as orientation hub

### DIFF
--- a/docs/dna-distro.md
+++ b/docs/dna-distro.md
@@ -4,22 +4,18 @@ title: DNA Distribution
 
 # Overview
 
-The Nucleus DNA Distribution is a library of OpenMTA genetic constructs used to engineer synthetic cells. It includes the protein-coding genes of the [PURE](https://doi.org/10.1038/90802) cell-free expression system, a level-matched T7 promoter library, ribosome binding sites, terminators, fluorescent reporters, and regulatory circuit components.
+The Nucleus DNA Distribution is a free to use library of DNA without patent or material transfer restrictions. These DNA sequences are used to build the [Modules](./modules/modules-main.md) reported here in Nucleus Docs. Each module specification should describe how to use the DNA (and other components) comprising the module. Digital sequences are maintained in the companion [nucleus-eng/DNA](https://github.com/nucleus-eng/DNA) repository. The repository [README](https://github.com/nucleus-eng/DNA/blob/main/README.md) describes the structure and contents of the DNA distribution.
 
-These constructs are the physical materials referenced throughout the [Modules](./modules/modules-main.md) and [Processes](./processes/processes-main.md) sections of this site. To request access to the distribution, join the [mailing list](https://bnextbio.typeform.com/nucleus-signup) or [contact us](mailto:build@bnext.bio).
+# Usage
 
-# The DNA repository
+Most sequences come in the `pOpen` plasmid (*E coli.* medium copy, ampicilin) and follow the naming pattern `pOpen-[part-name]`. `pOpen-pT7` constructs come with a T7 promoter and are appropriate DNA templates for reactions in [Nucleus Cytosol](./modules/base-cytosol/spec.md) and other PURE-derived systems. `pOpen` plasmids are NOT good expression vectors for protein production.
 
-All sequences are maintained in the companion [nucleus-eng/DNA](https://github.com/nucleus-eng/DNA) repository as GenBank (`.gb`) files, which open in [Benchling](https://benchling.com), [SnapGene](https://www.snapgene.com/), or any sequence editor that supports the format.
-
-Most parts use the MoClo-compatible `pOpen` entry-vector backbone and follow the naming pattern `pOpen-[part-name]`; PURE protein expression constructs use the `pET28a` backbone and follow `pET28a-[protein-name]`. The repository [README](https://github.com/nucleus-eng/DNA/blob/main/README.md) is the canonical description of its structure and contents.
+Expression vectors specifically for protein expression use the `pET28a` backbone (*E. coli* medium copy, kanamycin) and follow the naming pattern `pET28a-[protein-name]`. Most genes included in `pET28a` include 6xHis tags, making them ready for [Ni2+ Affinity Purification](./processes/make-protein/purify-proteins-grav-column/main.md). 
 
 # Where to find things
 
-This page orients you to the distribution; the details live in three places.
-
-| To find... | Look in... |
-| --- | --- |
+| To find...                              | Look in...                                               |
+| --------------------------------------- | -------------------------------------------------------- |
 | Sequence files for a specific construct | the [DNA repository](https://github.com/nucleus-eng/DNA) |
-| What a component does and how it behaves | [Modules](./modules/modules-main.md) |
-| Lab protocols that use these constructs | [Processes](./processes/processes-main.md) |
+| What a sequence does and how to use it  | [Modules](./modules/modules-main.md)                     |
+| Lab protocols that use these constructs | [Processes](./processes/processes-main.md)               |

--- a/docs/dna-distro.md
+++ b/docs/dna-distro.md
@@ -2,10 +2,24 @@
 title: DNA Distribution
 ---
 
-The Nucleus DNA Distribution consists of OpenMTA genetic constructs that can be used to engineer synthetic cells. 
+# Overview
 
-:::{attention}
+The Nucleus DNA Distribution is a library of OpenMTA genetic constructs used to engineer synthetic cells. It includes the protein-coding genes of the [PURE](https://doi.org/10.1038/90802) cell-free expression system, a level-matched T7 promoter library, ribosome binding sites, terminators, fluorescent reporters, and regulatory circuit components.
 
-The documentation for DNA Distribution can be found on the legacy site [here](https://nucleus.bnext.bio/DNA-Distribution-6d3e45ae88b84a038828b815ed54e8bc). 
+These constructs are the physical materials referenced throughout the [Modules](./modules/modules-main.md) and [Processes](./processes/processes-main.md) sections of this site. To request access to the distribution, join the [mailing list](https://bnextbio.typeform.com/nucleus-signup) or [contact us](mailto:build@bnext.bio).
 
-:::
+# The DNA repository
+
+All sequences are maintained in the companion [nucleus-eng/DNA](https://github.com/nucleus-eng/DNA) repository as GenBank (`.gb`) files, which open in [Benchling](https://benchling.com), [SnapGene](https://www.snapgene.com/), or any sequence editor that supports the format.
+
+Most parts use the MoClo-compatible `pOpen` entry-vector backbone and follow the naming pattern `pOpen-[part-name]`; PURE protein expression constructs use the `pET28a` backbone and follow `pET28a-[protein-name]`. The repository [README](https://github.com/nucleus-eng/DNA/blob/main/README.md) is the canonical description of its structure and contents.
+
+# Where to find things
+
+This page orients you to the distribution; the details live in three places.
+
+| To find... | Look in... |
+| --- | --- |
+| Sequence files for a specific construct | the [DNA repository](https://github.com/nucleus-eng/DNA) |
+| What a component does and how it behaves | [Modules](./modules/modules-main.md) |
+| Lab protocols that use these constructs | [Processes](./processes/processes-main.md) |


### PR DESCRIPTION
## Summary
Closes #45 

- Rewrites the `docs/dna-distro.md` stub (a one-line pointer to the legacy Notion site) into a thin orientation hub.
- Page now covers: what the DNA Distribution is, a pointer to the canonical [nucleus-eng/DNA](https://github.com/nucleus-eng/DNA) repository, plasmid/usage conventions (`pOpen` vs `pET28a`), and a "where to find things" map (sequences → repo, component behavior → Modules, protocols → Processes).
- Deliberately does **not** duplicate the DNA repo README's structure/inventory, plate maps, or construct tables — that content stays in the repo to keep maintenance low. Per #45, this supersedes the "migrate everything" intent of #4.

## Follow-up (not in this PR)
- The "how to use" lab/acquisition content (transform, prep, obtain) is tracked in #76. "How to obtain DNA" is partly blocked on negotiating distribution via AddGene. Forward links to those pages are intentionally omitted until they exist.

## Test plan
- [x] `vale docs/dna-distro.md` — clean
- [x] `python3 scripts/check-links.py docs/dna-distro.md` — all links OK

Refs #45, #4, #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)