### PR TITLE
fix: point protocol downloads at generated PDFs (make-36pot, assemble-*)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ Markers the generator keys off: `# Protocol` heading (pages without one are skip
 **Rules:**
 - `generated/` is gitignored (`**/generated/`) — never commit PDFs/CSVs. Treat `resources/` as source assets, `generated/` as derived.
 - Download buttons point at the relative generated path, e.g. `` {button}`download <generated/<slug>-protocol.pdf>` ``. MyST resolves these at build time, so **generation must run before `myst build`** (the deploy/CI ordering). Only include a BOM button if the page has a `bom-<slug>` table.
-- A page's materials/BOM table must be labeled `bom-<slug>` to be picked up (the slug must match the directory name). `scripts/check-bom-labels.py` enforces this (label matches directory; BOM download buttons have a backing table) and runs on PRs via `.github/workflows/protocols.yml`.
+- A page's materials/BOM table must be labeled `bom-<slug>` to be picked up (the slug must match the directory name). `scripts/check-bom-labels.py` enforces the download/label conventions (bom label matches directory; BOM download buttons have a backing table; protocol download buttons point at `generated/<slug>-protocol.pdf`, not a placeholder or another page's PDF) and runs on PRs via `.github/workflows/protocols.yml`.
 
 ### Prose formatting
 

--- a/docs/processes/assemble-base-cell/main.md
+++ b/docs/processes/assemble-base-cell/main.md
@@ -200,18 +200,12 @@ Do not transfer the entire solution. It is important to avoid transferring the t
 
 # Downloads
 
-::::{grid} 1 1 1 2
+::::{grid} 1 1 1 1
 
 :::{card}
 :header: **Lab-ready Protocol**
-:align: center
 
-{button}`download <../../modules/reporter-degfp/module-protocol-cells-degfp.pdf>`
-:::
-
-:::{card}
-:header: **Bill of Materials**
-{button}`download <../../modules/reporter-degfp/module-bom-reporter-cells-degfp.pdf>`
+{button}`download <generated/assemble-base-cell-protocol.pdf>`
 :::
 
 ::::

--- a/docs/processes/assemble-base-cytosol/main.md
+++ b/docs/processes/assemble-base-cytosol/main.md
@@ -140,21 +140,15 @@ To avoid introducing bubbles, use reverse pipetting to array your samples. With 
 ## Return reagents to their appropriate storage locations
 - [ ] Mark the lid of each Cytosol component that you used. The number of dots indicates how many freeze–thaw cycles each component has gone through.
 
-# Downloads sss
+# Downloads
 
 :::::{card}
 :header: **Resources**
-::::{grid} 1 1 1 2
+::::{grid} 1 1 1 1
 
 :::{card}
 :header: **Lab-ready Protocol**
-{button}`download <../../modules/reporter-degfp/module-protocol-cytosol-degfp.pdf>`
-:::
-
-
-:::{card}
-:header: **Bill of Materials**
-{button}`download <../../modules/reporter-degfp/module-bom-reporter-degfp.pdf>`
+{button}`download <generated/assemble-base-cytosol-protocol.pdf>`
 :::
 
 ::::

--- a/docs/processes/make-36pot/main.md
+++ b/docs/processes/make-36pot/main.md
@@ -161,9 +161,8 @@ Washing the assembled mix before concentrating removes residual salts (Na+, Imid
 
 :::{card}
 :header: **Lab-ready Protocol**
-:align: center
 
-{button}`download <TODO: protocol.pdf>`
+{button}`download <generated/make-36pot-protocol.pdf>`
 :::
 
 :::{card}

--- a/scripts/check-bom-labels.py
+++ b/scripts/check-bom-labels.py
@@ -1,18 +1,21 @@
 #!/usr/bin/env python3
 """
-check-bom-labels.py — enforce the lab-ready pipeline's BOM conventions on
-process pages (see issue #10).
+check-bom-labels.py — enforce the lab-ready pipeline's download/label
+conventions on process pages (see issue #10).
 
-The lab-ready pipeline (scripts/build-protocols.py) generates a Bill of
-Materials PDF + materials CSV from a table labeled ``bom-<slug>``, where
-``<slug>`` is the process's directory name. Download buttons point at the
-generated artifacts. Two things must hold or the build breaks / artifacts go
-missing:
+The lab-ready pipeline (scripts/build-protocols.py) generates a protocol PDF, a
+Bill of Materials PDF, and a materials CSV from each process page; download
+buttons point at the generated artifacts under ``generated/<slug>-*.pdf`` where
+``<slug>`` is the process's directory name. This check enforces:
 
   1. A ``bom-<...>`` table label must match its directory — ``bom-<dir-name>``.
      A renamed directory with a stale label silently stops generating the BOM.
   2. A page that links a generated BOM download (``generated/<slug>-bom.pdf``)
      must have a ``bom-<slug>`` table, or the download dangles / the build fails.
+  3. Any protocol-PDF download button must point at ``generated/<slug>-protocol.pdf``
+     — not a ``TODO``/placeholder path or some other page's PDF. (Catches the
+     stale-button class that slipped through the initial rollout: a page that
+     migrated from stub or template still pointing at the old target.)
 
 Reports violations as ``file:line`` and exits non-zero if any are found.
 
@@ -29,6 +32,8 @@ PROCESSES_ROOT = Path("docs/processes")
 
 BOM_LABEL_RE = re.compile(r"^\s*:label:\s*(bom-[A-Za-z0-9._-]+)\s*$")
 BOM_DOWNLOAD_RE = re.compile(r"download\s*<generated/([A-Za-z0-9._-]+)-bom\.pdf>")
+# Any `download <target>` reference, to inspect the target.
+DOWNLOAD_RE = re.compile(r"download\s*<([^>]+)>")
 
 
 def find_pages(args):
@@ -71,6 +76,19 @@ def check_page(path):
                 (i, f"links a BOM download but the page has no '{expected}' labeled table")
             )
 
+    # Rule 3: a protocol-PDF download button must point at the generated path.
+    expected_protocol = f"generated/{slug}-protocol.pdf"
+    for i, line in enumerate(lines, start=1):
+        for target in DOWNLOAD_RE.findall(line):
+            target = target.strip()
+            is_protocol_ref = "protocol" in target.lower() and (
+                target.lower().endswith(".pdf") or "todo" in target.lower()
+            )
+            if is_protocol_ref and target != expected_protocol:
+                violations.append(
+                    (i, f"protocol download '{target}' should be '{expected_protocol}'")
+                )
+
     return violations
 
 
@@ -88,7 +106,7 @@ def main():
             total += 1
 
     if total:
-        print(f"\n❌ {total} BOM-label violation(s) found.")
+        print(f"\n❌ {total} download/label convention violation(s) found.")
         return 1
     print(f"✅ {len(pages)} process page(s) OK.")
     return 0


### PR DESCRIPTION
## Summary

Follow-up to #84. A full audit of process download buttons turned up three pages whose **Lab-ready Protocol** button didn't point at the generated PDF — they were stubs or used unrelated PDFs when the pipeline landed, so the #84 rewiring missed them:

- **make-36pot** — `TODO: protocol.pdf` placeholder → `generated/make-36pot-protocol.pdf`. (Its real content arrived via #83 *after* the pipeline branch forked, so it carried the template placeholder.)
- **assemble-base-cell** / **assemble-base-cytosol** — pointed at deGFP **module** protocol/BOM PDFs → their own `generated/<slug>-protocol.pdf`. Dropped the BOM buttons (neither has a `bom-<slug>` table) and fixed a `# Downloads sss` typo.

`make-1pot` left as-is — it's a stub with no protocol steps, so the pipeline generates no PDF for it yet.

## Test plan

- [x] All three pages render (make-36pot 36 lines, assemble-base-cell 68, assemble-base-cytosol 31)
- [x] Full `myst build --html` resolves the new buttons; PDFs published into the site
- [x] `vale` + `check-bom-labels.py` clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)