### PR TITLE
feat: add liposome workshop guide page

### DIFF
--- a/docs/modules/modules-main.md
+++ b/docs/modules/modules-main.md
@@ -6,19 +6,38 @@ title: Modules
 
 A Module is a useful biochemical formulation, often incorporating a genetically encoded component, that performs a particular function. Modules Specifications answer the questions 1) "What is it?" and 2) "What should I expect when I implement it?".
 
+**Validation key:** ★★★★ validated in cells, frequently reused · ★★★ validated in cells · ★★ validated in vitro · ★ preliminary / DevNote only
+
+## PURExpress
+
+Modules validated in [NEB PURExpress](https://www.neb.com/en-us/products/e6800-purexpress-invitro-protein-synthesis-kit).
+
 :::{table}
 
-| Module Class | Module Implementation | Base Module | Status |
-| --- | --- | --- | --- |
-| Base | [Cytosol](./base-cytosol/spec.md) | - | Specification |
-| Reporter | [deGFP](./reporter-degfp/spec.md) | Base Cytosol | Specification |
-| Membrane (Base) | [POPC/Chol](./membrane-popc-chol/spec.md) | Base Cytosol, PURExpress | Specification |
-| Detector | [tetR-aTc](./detector-tetr_atc/spec.md) | PURExpress | Specification |
-| Emitter | [IV-HSL](./emitter-ivhsl/spec.md) | PURExpress | Specification |
-| Energy | [PPK](./energy-ppk/spec.md) | PURExpress | Specification |
-| Control | [ClpXP](./control-clpxp/spec.md) | PURExpress | Specification |
-| Membrane Pore | [α-Hemolysin](./membrane-pore-ahly/spec.md) | PURExpress  | Specification |
-|  | [Cx43](./membrane-pore-cx43/spec.md) | PURExpress | DevNote |
+| Module Class | Specification | Validation |
+| --- | --- | --- |
+| Membrane (Base) | [POPC/Chol](./membrane-popc-chol/spec.md) | ★★★★ |
+| Detector | [tetR-aTc](./detector-tetr_atc/spec.md) | ★★★ |
+| Emitter | [IV-HSL](./emitter-ivhsl/spec.md) | ★★★ |
+| Energy | [PPK](./energy-ppk/spec.md) | ★★ |
+| Control | [ClpXP](./control-clpxp/spec.md) | ★★★ |
+| Membrane Pore | [α-Hemolysin](./membrane-pore-ahly/spec.md) | ★★ |
+| | [Cx43](./membrane-pore-cx43/spec.md) | ★ |
+
+:::
+
+## Nucleus Cytosol
+
+Modules validated in [Nucleus Cytosol](./base-cytosol/spec.md).
+
+:::{table}
+
+| Module Class | Specification | Validation |
+| --- | --- | --- |
+| Base | [Cytosol](./base-cytosol/spec.md) | ★★★★ |
+| Reporter | [deGFP](./reporter-degfp/spec.md) | ★★★★ |
+| Membrane (Base) | [POPC/Chol](./membrane-popc-chol/spec.md) | ★★★★ |
+
 :::
 
 # Contributing a Module

--- a/docs/modules/modules-main.md
+++ b/docs/modules/modules-main.md
@@ -6,7 +6,7 @@ title: Modules
 
 A Module is a useful biochemical formulation, often incorporating a genetically encoded component, that performs a particular function. Modules Specifications answer the questions 1) "What is it?" and 2) "What should I expect when I implement it?".
 
-**Validation key:** ★★★★ validated in cells, frequently reused · ★★★ validated in cells · ★★ validated in vitro · ★ preliminary / DevNote only
+**Validation key:** ★★★ frequently used, ★★ validated (cells or in vitro),  ★ preliminary / DevNote only
 
 ## PURExpress
 
@@ -16,12 +16,12 @@ Modules validated in [NEB PURExpress](https://www.neb.com/en-us/products/e6800-p
 
 | Module Class | Specification | Validation |
 | --- | --- | --- |
-| Membrane (Base) | [POPC/Chol](./membrane-popc-chol/spec.md) | ★★★★ |
-| Detector | [tetR-aTc](./detector-tetr_atc/spec.md) | ★★★ |
-| Emitter | [IV-HSL](./emitter-ivhsl/spec.md) | ★★★ |
-| Energy | [PPK](./energy-ppk/spec.md) | ★★ |
-| Control | [ClpXP](./control-clpxp/spec.md) | ★★★ |
-| Membrane Pore | [α-Hemolysin](./membrane-pore-ahly/spec.md) | ★★ |
+| Membrane (Base) | [POPC/Chol](./membrane-popc-chol/spec.md) | ★★★ |
+| Detector | [tetR-aTc](./detector-tetr_atc/spec.md) | ★★ |
+| Emitter | [IV-HSL](./emitter-ivhsl/spec.md) | ★★ |
+| Control | [ClpXP](./control-clpxp/spec.md) |★★ |
+| Energy | [PPK](./energy-ppk/spec.md) | ★ |
+| Membrane Pore | [α-Hemolysin](./membrane-pore-ahly/spec.md) | ★ |
 | | [Cx43](./membrane-pore-cx43/spec.md) | ★ |
 
 :::
@@ -34,9 +34,9 @@ Modules validated in [Nucleus Cytosol](./base-cytosol/spec.md).
 
 | Module Class | Specification | Validation |
 | --- | --- | --- |
-| Base | [Cytosol](./base-cytosol/spec.md) | ★★★★ |
-| Reporter | [deGFP](./reporter-degfp/spec.md) | ★★★★ |
-| Membrane (Base) | [POPC/Chol](./membrane-popc-chol/spec.md) | ★★★★ |
+| Cytosol (Base) | [Cytosol](./base-cytosol/spec.md) | ★★★ |
+| Membrane (Base) | [POPC/Chol](./membrane-popc-chol/spec.md) | ★★★ |
+| Reporter | [deGFP](./reporter-degfp/spec.md) | ★★★ |
 
 :::
 

--- a/guides/liposome-workshop/main.md
+++ b/guides/liposome-workshop/main.md
@@ -13,16 +13,11 @@ The workshop materials are designed to be self-contained and reusable — suitab
 
 The following materials are available for download. All materials are hosted on Google Drive.
 
-| Material | Description | Download |
-| --- | --- | --- |
-| Schedule | Two-day workshop agenda | [link](https://drive.google.com/file/d/1OfpRAEnXCfryIM4ZkQaUzgBTLv-SCfl1/view?usp=sharing) |
-| Slides: Liposomes 101 (PDF) | Introductory lecture on liposome biology and construction — view or print | [link](https://drive.google.com/file/d/1vUsiyeOotjB9foFpe_E4hePGg_5HjPyg/view?usp=sharing) |
-| Slides: Liposomes 101 (PPTX) | Editable source deck for adapting the workshop | [link](https://docs.google.com/presentation/d/112khfISOijuh5c-ic0Sb5quvrbT2rb8t/edit?usp=sharing) |
-| Protocol | Hello World Liposomes bench protocol (v0.1.3) | [link](https://drive.google.com/file/d/1-AcwaR10UhigOU6P87aD1eDCQt_ahstX/view?usp=sharing) |
-| Bill of Materials | Consumables and reagents list for the full workshop | [link](https://drive.google.com/file/d/1IYDTbg4SJDD9Z0eaW17Y7zWI7zg6Mn_7/view?usp=sharing) |
-
-:::{note} Syncell 101 slides
-A second lecture covering synthetic cell design principles is forthcoming.
-:::
+| Material                              | Description                                                               | Download                                                                                          |
+| ------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Schedule                              | Two-day workshop agenda                                                   | [link](https://drive.google.com/file/d/1OfpRAEnXCfryIM4ZkQaUzgBTLv-SCfl1/view?usp=sharing)        |
+| Slides: Liposomes 101 (.pdf)          | Introductory lecture on liposome biology and construction — view or print | [link](https://drive.google.com/file/d/1vUsiyeOotjB9foFpe_E4hePGg_5HjPyg/view?usp=sharing)        |
+| Protocol                              | Hello World Liposomes bench protocol (v0.1.3)                             | [link](https://drive.google.com/file/d/1-AcwaR10UhigOU6P87aD1eDCQt_ahstX/view?usp=sharing)        |
+| Bill of Materials                     | Consumables and reagents list for the full workshop                       | [link](https://drive.google.com/file/d/1IYDTbg4SJDD9Z0eaW17Y7zWI7zg6Mn_7/view?usp=sharing)        |
 
 Protocol v0.1.3 (updated April 2025).

--- a/guides/liposome-workshop/main.md
+++ b/guides/liposome-workshop/main.md
@@ -1,0 +1,30 @@
+---
+title: "Liposome Workshop"
+subtitle: "Guide"
+---
+
+# Overview
+
+The Nucleus Liposome Workshop is a two-day hands-on curriculum for introducing new cell builders to liposome construction using the Nucleus Distribution. Participants build and characterize synthetic cells using the PURE Cell platform, working through a guided protocol from lipid preparation through encapsulation and imaging.
+
+The workshop materials are designed to be self-contained and reusable — suitable for university courses, lab onboarding, or community science events. If you are interested in running a workshop or have questions about the materials, reach out to [build@bnext.bio](mailto:build@bnext.bio).
+
+# Materials
+
+The following materials are available for download. Hosted assets will be linked here once available on Google Drive.
+
+| Material | Description | Download |
+| --- | --- | --- |
+| Schedule | Two-day workshop agenda | TODO |
+| Slides: Liposomes 101 | Introductory lecture on liposome biology and construction | TODO |
+| Protocol | Hello World Liposomes bench protocol (v0.1.3) | TODO |
+| Bill of Materials | Consumables and reagents list for the full workshop | TODO |
+
+:::{note} Syncell 101 slides
+A second lecture covering synthetic cell design principles is forthcoming.
+:::
+
+# Changelog
+
+- **v0.1.3** — Current protocol version. Updated lipid reference from lyophilized LissRhod PE (18:1) to LissRhod PE (16:0) suspended in chloroform.
+- **v0.1.1** — Deprecated. Contained reference to lyophilized LissRhod PE (18:1).

--- a/guides/liposome-workshop/main.md
+++ b/guides/liposome-workshop/main.md
@@ -11,20 +11,18 @@ The workshop materials are designed to be self-contained and reusable — suitab
 
 # Materials
 
-The following materials are available for download. Hosted assets will be linked here once available on Google Drive.
+The following materials are available for download. All materials are hosted on Google Drive.
 
 | Material | Description | Download |
 | --- | --- | --- |
-| Schedule | Two-day workshop agenda | TODO |
-| Slides: Liposomes 101 | Introductory lecture on liposome biology and construction | TODO |
-| Protocol | Hello World Liposomes bench protocol (v0.1.3) | TODO |
-| Bill of Materials | Consumables and reagents list for the full workshop | TODO |
+| Schedule | Two-day workshop agenda | [link](https://drive.google.com/file/d/1OfpRAEnXCfryIM4ZkQaUzgBTLv-SCfl1/view?usp=sharing) |
+| Slides: Liposomes 101 (PDF) | Introductory lecture on liposome biology and construction — view or print | [link](https://drive.google.com/file/d/1vUsiyeOotjB9foFpe_E4hePGg_5HjPyg/view?usp=sharing) |
+| Slides: Liposomes 101 (PPTX) | Editable source deck for adapting the workshop | [link](https://docs.google.com/presentation/d/112khfISOijuh5c-ic0Sb5quvrbT2rb8t/edit?usp=sharing) |
+| Protocol | Hello World Liposomes bench protocol (v0.1.3) | [link](https://drive.google.com/file/d/1-AcwaR10UhigOU6P87aD1eDCQt_ahstX/view?usp=sharing) |
+| Bill of Materials | Consumables and reagents list for the full workshop | [link](https://drive.google.com/file/d/1IYDTbg4SJDD9Z0eaW17Y7zWI7zg6Mn_7/view?usp=sharing) |
 
 :::{note} Syncell 101 slides
 A second lecture covering synthetic cell design principles is forthcoming.
 :::
 
-# Changelog
-
-- **v0.1.3** — Current protocol version. Updated lipid reference from lyophilized LissRhod PE (18:1) to LissRhod PE (16:0) suspended in chloroform.
-- **v0.1.1** — Deprecated. Contained reference to lyophilized LissRhod PE (18:1).
+Protocol v0.1.3 (updated April 2025).

--- a/guides/main.md
+++ b/guides/main.md
@@ -20,6 +20,10 @@ Guides provide tutorials, how-tos, and reference documentation to help you get t
 - [Tutorial: Analyzing Platereader Data](platereader_tutorial.md) — analyze cytosol kinetics data using the Nucleus CDK
 - [Tutorial: Making a Nucleus Compatible Plate Map](platemap_tutorial.md) — format and submit platemaps for use with CDK tools
 
+## Workshops
+
+- [Liposome Workshop](liposome-workshop/main.md) — two-day hands-on curriculum for building synthetic cells using the PURE Cell platform
+
 ## Contributing
 
 - [Contribution Guidelines](contribution-guide.md) — requirements and recommendations for submitting a contribution to the Distribution

--- a/myst.yml
+++ b/myst.yml
@@ -103,6 +103,8 @@ project:
           hidden: true
         - file: ./guides/platemap_tutorial.md
           hidden: true
+        - file: ./guides/liposome-workshop/main.md
+          hidden: true
     - title: About
       children:
         # - file: ./about/open-science.md


### PR DESCRIPTION
## Summary

- Adds `guides/liposome-workshop/main.md` — a landing page for the Nucleus Liposome Workshop with overview, materials table, and current version note
- Adds `## Workshops` section to `guides/main.md` with the liposome workshop as the first entry
- Wires up TOC entry in `myst.yml`

## Materials linked

All assets hosted on Google Drive (view-only):
- Workshop schedule
- Liposomes 101 slides (PDF + PPTX)
- Hello World Liposomes Protocol (v0.1.3)
- Bill of Materials

## Notes

- Syncell 101 slides are forthcoming — noted inline with a `:::{note}` block
- Resources folder contains the Notion export for reference but is not committed
- Inline changelog replaced with a single current version line — version history to be tracked in Git/issues going forward

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)