### PR TITLE
feat: update intro.md to reflect high-level site structure

### DIFF
--- a/intro.md
+++ b/intro.md
@@ -8,10 +8,7 @@ site:
 
 If you're new to Nucleus, check out [From Zero to DevNote](./start/first-guide.md). This Guide will walk you through the documentation while introducing you to the specific Nucleus tools. 
 
-# Protocols
-
 :::::{card}
-:footer: We are migrating protocols from our legacy site as modules are validated in Nucleus Cytosol v0.5
 
 ::::{grid} 1 1 2 2
 
@@ -40,12 +37,14 @@ Modules extend the functionality of Base Cytosol and Cells.
 Implementations are useful combinations of Modules and Processes.
 :::
 
+:::{card}
+:header: 📖 **Guides**
+:link: guides/main.md
+Tutorials, how-tos, and workshop materials for using the Nucleus Distribution and its digital tools.
+:::
+
 ::::
 :::::
-
-# Guides
-
-Guides contain tutorials, how-tos, and other reference material that support the use of Protocols and navigating the Nucleus Development Cycle.
 
 # Get in touch
 


### PR DESCRIPTION
## Summary

- Drops the misleading `# Protocols` section heading — the card grid covers the full distribution, not just protocols
- Adds a **Guides** card to the content grid alongside Processes, Modules, Implementations, and DNA Distribution
- Removes the outdated migration footer note ("We are migrating protocols from our legacy site as modules are validated in Nucleus Cytosol v0.5") — migration is ongoing but not contingent on Cytosol validation, and the framing was misleading given that PURExpress modules are also actively documented

## Notes

- The 5-card grid produces a 3-2 layout at some viewports — intentionally left as-is. Will resolve naturally when the CDK documentation page is added as a 6th card (tracked separately)
- DNA Distribution card placement may also be revisited at that point

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)