### PR TITLE
clean up PPK drop down

### DIFF
--- a/docs/modules/energy-ppk/spec.md
+++ b/docs/modules/energy-ppk/spec.md
@@ -13,7 +13,7 @@ The PPK energy Module generates ATP and  GTP from AMP and GDP, respectively, usi
 
 :::{attention}
 
-This Module has not been validated in Nucleus Cytosol $\ge$ v0.5. Documentation can be found on our legacy site [here](https://nucleus.bnext.bio/PPK-Energy-Module-2dcae616eb5180828931f0421467ad20) and in the following DevNotes:
+This Module has not been validated in Nucleus Cytosol $\ge$ v0.5. Documentation can be found here and in the following DevNotes:
 
 - [Integrating PPK Module in PURE Cells](https://doi.org/10.63765/mwur3749)
 - [PPK Module testing in PURE](https://doi.org/10.63765/djnv7772)


### PR DESCRIPTION
Cleans up a dropdown that pointed to the legacy documentation and called it a stub page
