### PR TITLE
fix: add typst to local conda environment (#102)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - nodejs=24
   - pip
   - python=3.13
+  - typst=0.14.2
   - pip:
     - jupyter-book>=2.1.4
 


### PR DESCRIPTION
## Summary

Fixes #102. Local dev setups hit `The typst CLI must be installed to build PDFs with typst` when running `jupyter book build --pdf` or `scripts/build-protocols.py`, because the conda env never installed typst — only CI did (via the `curl` step in `deploy.yml`/`protocols.yml`).

This adds `typst=0.14.2` to `environment.yml`, pinned to match the version CI installs so local and CI PDF renders stay in lockstep. Anyone running `setup.sh` now gets typst on PATH automatically.

## Validation

- `conda env create --dry-run` resolves cleanly with `typst==0.14.2` and no conflicts against the existing deps.

## Notes

- Existing local envs won't pick up typst until they re-run `setup.sh` (which removes + recreates the env) or `conda install -c conda-forge typst=0.14.2`. Expected for an env-file change.
- CI's `curl`-based typst install is left untouched — CI doesn't use conda, so it's a separate, already-working path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)