### PR TITLE
refactor(check-links): extract HTTP/2 false-positive domains into TOML config (#71)

### DIFF
--- a/scripts/check-links.py
+++ b/scripts/check-links.py
@@ -21,16 +21,23 @@ import json
 import shutil
 import subprocess
 import sys
-
-# Domains that kill HTTP/2 connections at the protocol level.
-# These are not dead links — they are valid URLs on servers that block crawlers.
-# Any other error type from these domains (404, DNS failure, etc.) will still
-# be reported as a genuine error.
-HTTP2_FALSE_POSITIVE_DOMAINS = [
-    "sigmaaldrich.com",
-]
+import tomllib
+from pathlib import Path
 
 HTTP2_ERROR_SUBSTRING = "HTTP/2 protocol error"
+
+_CONFIG_PATH = Path(__file__).with_name("link-false-positives.toml")
+
+def _load_false_positive_domains() -> list[str]:
+    try:
+        with _CONFIG_PATH.open("rb") as f:
+            data = tomllib.load(f)
+    except FileNotFoundError:
+        return []
+    return data.get("http2_false_positives", {}).get("domains", [])
+
+
+HTTP2_FALSE_POSITIVE_DOMAINS = _load_false_positive_domains()
 
 
 def is_http2_false_positive(url: str, error_text: str) -> bool:

--- a/scripts/link-false-positives.toml
+++ b/scripts/link-false-positives.toml
@@ -1,0 +1,9 @@
+# Vendor domains that terminate HTTP/2 connections at the protocol level.
+# These are valid URLs — lychee reports a spurious "HTTP/2 protocol error" for them.
+# Any OTHER error type from these domains (404, DNS failure, etc.) is still reported.
+# Add a domain substring here to suppress the false positive without touching Python.
+
+[http2_false_positives]
+domains = [
+    "sigmaaldrich.com",
+]


### PR DESCRIPTION
## Summary

- Moves the hardcoded `sigmaaldrich.com` domain list out of `check-links.py` into `scripts/link-false-positives.toml`
- Loads it at module init via `tomllib` (stdlib, Python 3.11+; CI uses 3.13)
- Zero behavior change — all downstream logic is unchanged

Non-developers can now add a vendor domain to suppress HTTP/2 false positives without touching Python.

Closes #71.

## Test plan
- [ ] Verify `python3 -c "import tomllib; print(tomllib.load(open('scripts/link-false-positives.toml','rb')))"` prints expected domains
- [ ] Run `python3 scripts/check-links.py docs/` on a machine with lychee — confirms ℹ️ filtering line still prints for sigmaaldrich URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)