### PR TITLE
docs(#87): add 14 migration conventions to CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ dep/
 **/resources/Private & Shared*/
 **/resources/*-notion.md
 
+# DevNote numbered export folders (e.g. 09-cx43_cell/) — raw exports, never committed
+**/resources/[0-9][0-9]-*/
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,12 +72,20 @@ DNA/
    ```
    The README is maintained as the canonical description of the repo structure.
 
+4. **If `~/src/nucleus-eng/DNA` is not on this machine** — use the GitHub API as a fallback to browse the repo or inspect construct files without cloning:
+   ```bash
+   # Browse a directory (e.g. detectors/)
+   gh api "repos/nucleus-eng/DNA/contents/detectors" --jq '.[].name'
+   # Decode a GenBank file and read the LOCUS line for construct length
+   gh api "repos/nucleus-eng/DNA/contents/detectors/pOpen-LacI-IPTG.gb" --jq '.content' | base64 -d | grep "^LOCUS"
+   ```
+
 **Key rules when working across both repos:**
 
 - **Do not create or store `.gb` sequence files in nucleus-docs.** All DNA sequences belong in the DNA repo.
 - **Construct names in protocol pages must match actual filenames** in the DNA repo (e.g., a step that says "use `pOpen-PURET7-3`" corresponds to `promoters/pOpen-PURET7-3.gb`). Verify before writing.
 - **Cross-repo links** in doc pages should point to the GitHub URL of the `.gb` file in `nucleus-eng/DNA`, not to a local path.
-- **Changes to the DNA repo are out of scope for nucleus-docs PRs.** If a protocol requires a new construct that doesn't exist in the DNA repo yet, flag that to the developer rather than creating a placeholder.
+- **Changes to the DNA repo are out of scope for nucleus-docs PRs.** If a construct referenced in a source page is not found in `nucleus-eng/DNA`, add an `:::{attention}` block in the spec noting the gap, e.g.: "Construct `pOpen-pT7-Cx43` is not yet in `nucleus-eng/DNA` (originated in `bnext-bio/nucleus`). Do not link to the legacy repo — flag for follow-up so the construct can be submitted to `nucleus-eng/DNA` before this page is used at the bench." DNA constructs referenced in a DevNote SHOULD be submitted to `nucleus-eng/DNA` before or alongside migration; if they are not present at migration time, apply the attention block and flag.
 
 ### Content model
 
@@ -99,9 +107,13 @@ The documentation organizes content into three parallel hierarchies under `docs/
 
 **Before creating or moving any file**, verify the target path matches this structure. If a file is about to land outside `docs/`, stop and flag it to the developer before proceeding.
 
+**Manufacturer PDFs and datasheets must not be committed to this repo.** Reference them via vendor URLs or host them externally. Until a shared hosting convention is established, add a `<!-- TODO: replace with hosted PDF link -->` comment on the download card in the `# Downloads` section rather than committing the file. Do not include vendor PDFs in PRs.
+
 ### Table of contents management
 
 The site TOC is defined entirely in `myst.yml`. When adding a new page, you must add it to the `toc:` section. Child pages that should not appear directly in the sidebar use `hidden: true`. The file `site.yml` holds site-wide settings (license, nav links, theme) that `myst.yml` extends.
+
+**Adding a module spec requires two table-of-contents updates, not one.** In addition to the `myst.yml` TOC entry, add a row to the table in `docs/modules/modules-main.md`. The table columns are `Module Class | Specification | Validation` — fill in the class name (e.g. `Detector`), a relative link to the spec (e.g. `[LacI-IPTG](./detector-laci_iptg/spec.md)`), and the validation star rating (use `★` for validated, `☆` for unvalidated, following the existing rows as a guide). Missing this step leaves the module off the main module index page.
 
 ### Templates
 
@@ -110,6 +122,8 @@ The site TOC is defined entirely in `myst.yml`. When adding a new page, you must
 - `module-template/spec.md` — module spec structure with schematic, designs table, compatible processes, and usage references
 - `implementation-template/implementation-template.md` — combined implementation format
 - `typst/nucleus-protocols/` — the branded typst template used to render lab-ready protocol/BOM PDFs (vendored in-repo; pubmatter pinned to 0.2.2 — see its README)
+
+**When migrating content into a pre-created stub directory**, scan for and delete any template placeholder files before committing. Stub directories are often created with placeholder images (e.g. `behavior/ppk-kinetics.png`, `behavior/ppk-endpoint.png`) that have no real data and were copied from the implementation template. Run `git ls-files docs/modules/<module>/` to see what's tracked, and `git rm` any placeholders that have not been replaced by real figures.
 
 ### Lab-ready protocol pipeline (issue #10)
 
@@ -138,6 +152,8 @@ Pages use MyST admonition nesting with `:::` fences. Process pages follow a cons
 4. `# Downloads` grid with cards linking to PDF lab protocol and Bill of Materials
 
 Protocol steps use `- [ ]` checkboxes and `:::{hint}` dropdowns for extended notes. Cross-references use MyST `{ref}` syntax for same-page targets and standard markdown links for cross-page references.
+
+**Tab-set fence depth.** Tab-sets require a consistent three-level nesting: the outer `{tab-set}` uses `:::::`(5 colons), each `{tab-item}` inside uses `::::` (4 colons), and figures or admonitions inside a tab-item use `:::` (3 colons). Mismatched colon counts are a common source of rendering failures.
 
 ### Overview card dropdowns — empty dropdown policy
 
@@ -179,6 +195,11 @@ When migrating content from Notion markdown exports:
 - **Notion `<aside>` blocks**: Convert to the appropriate MyST admonition or section header depending on context (e.g., "Getting Started" asides → Overview prose, "Step X" asides → `##` section headers, "Resources" asides → `# References`).
 - **Notion toggles**: Convert to `:::{hint} Note: <title>` with `:class: dropdown`.
 - **Units in table column headers**: Use parentheses, not brackets (e.g., `MW (g/mol)` not `MW [g/mol]`).
+- **Concentration discrepancies**: Reaction tables in Notion sources sometimes list a stock concentration that does not match the stated final concentration. Before migrating a table, verify that `stock concentration × volume / total volume = stated final concentration` for every reagent row. If a discrepancy is found, do not silently copy the values — add a `:::{warning}` block flagging the specific row(s) for author review before the page is used at the bench.
+- **Scope boundary — spec vs. process**: Protocol steps, materials tables, and imaging conditions from a DevNote belong in a future Process page, not the module spec. The spec covers what the module is, its genetic designs, and expected performance. If protocol-level content appears in the DevNote, note it with a `<!-- TODO: move to process page -->` comment rather than migrating it into the spec.
+- **DevNote migration start — read `curvenote.yml` first**: `curvenote.yml` is the single best starting point for a DevNote migration. It contains the DOI, project ID, author list (with ORCIDs and affiliations), figure sources, and download files. Read it before `main.md` to orient to the content.
+- **DevNote figures — use static PNGs with `:name:` labels**: Computed figures (e.g. from Jupyter notebook outputs or `lorem.mjs`) cannot be copied as static images and cannot be cross-referenced from nucleus-docs. Key result figures in a module spec should be static PNG files with explicit `:name: fig:something` labels in `main.md`. Only figures with `:name:` labels are reachable via `xref:<devnote-key>#fig:something` in spec pages.
+- **Bare DOI citations from Curvenote**: Curvenote DevNotes use `[](10.xxxx/xxxxx)` as a shorthand DOI citation. This resolves as a local file path in the nucleus-docs MyST build and causes a link-checker error. Always replace with a full markdown link on migration: `[Author et al., year](https://doi.org/10.xxxx/xxxxx)`. Check for bare `[](` patterns with `grep -n '\[\](' <file>` before committing a migrated spec.
 
 ### External references
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,7 @@ The documentation organizes content into three parallel hierarchies under `docs/
 | New implementation | `docs/implementations/<implementation-name>/` |
 | Process sub-resources (BOMs, images) | `docs/processes/<process-name>/resources/` |
 | Module images | `docs/modules/<module-name>/` |
+| Module raw assets (Notion/DevNote exports, source files) | `docs/modules/<module-name>/resources/` |
 
 **Before creating or moving any file**, verify the target path matches this structure. If a file is about to land outside `docs/`, stop and flag it to the developer before proceeding.
 
@@ -155,6 +156,10 @@ Protocol steps use `- [ ]` checkboxes and `:::{hint}` dropdowns for extended not
 
 **Tab-set fence depth.** Tab-sets require a consistent three-level nesting: the outer `{tab-set}` uses `:::::`(5 colons), each `{tab-item}` inside uses `::::` (4 colons), and figures or admonitions inside a tab-item use `:::` (3 colons). Mismatched colon counts are a common source of rendering failures.
 
+**Secondary figures.** Within a section that has a primary figure (e.g. a performance plot), de-emphasize supplementary or supporting figures by wrapping them in a `::::{hint} <descriptive title>` block with `:class: dropdown`. The dropdown title should describe the finding, not just label the figure (e.g. `::::{hint} The Emitter Cell causes E. coli to express GFP in response to IV-HSL`). This keeps the primary figure prominent while keeping supporting context one click away.
+
+**System-context figure placement (module specs).** A figure showing the module in the context of the Base Cell or Developer Cell belongs in the `## Cells` section, not `# Overview`. The Overview section should carry mechanism and schematic figures only.
+
 ### Overview card dropdowns — empty dropdown policy
 
 The template includes all possible dropdown sections as a starting point. **When authoring or reviewing a process page, only keep dropdowns that have real content.** Delete any dropdown whose only content is `- None`.
@@ -195,7 +200,7 @@ When migrating content from Notion markdown exports:
 - **Notion `<aside>` blocks**: Convert to the appropriate MyST admonition or section header depending on context (e.g., "Getting Started" asides → Overview prose, "Step X" asides → `##` section headers, "Resources" asides → `# References`).
 - **Notion toggles**: Convert to `:::{hint} Note: <title>` with `:class: dropdown`.
 - **Units in table column headers**: Use parentheses, not brackets (e.g., `MW (g/mol)` not `MW [g/mol]`).
-- **Concentration discrepancies**: Reaction tables in Notion sources sometimes list a stock concentration that does not match the stated final concentration. Before migrating a table, verify that `stock concentration × volume / total volume = stated final concentration` for every reagent row. If a discrepancy is found, do not silently copy the values — add a `:::{warning}` block flagging the specific row(s) for author review before the page is used at the bench.
+- **Data discrepancies (including concentrations)**: Source content sometimes carries internally inconsistent or unverified values — a value in the body text that conflicts with a figure caption, or a stock concentration that does not match the stated final concentration. Do not silently correct or copy these — add a `:::{warning}` block adjacent to the affected content that names the specific discrepancy, shows the conflicting values, states the most likely interpretation, and instructs the reviewer to verify before bench use. For reaction tables specifically, verify that `stock concentration × volume / total volume = stated final concentration` for every reagent row, and flag any row that fails.
 - **Scope boundary — spec vs. process**: Protocol steps, materials tables, and imaging conditions from a DevNote belong in a future Process page, not the module spec. The spec covers what the module is, its genetic designs, and expected performance. If protocol-level content appears in the DevNote, note it with a `<!-- TODO: move to process page -->` comment rather than migrating it into the spec.
 - **DevNote migration start — read `curvenote.yml` first**: `curvenote.yml` is the single best starting point for a DevNote migration. It contains the DOI, project ID, author list (with ORCIDs and affiliations), figure sources, and download files. Read it before `main.md` to orient to the content.
 - **DevNote figures — use static PNGs with `:name:` labels**: Computed figures (e.g. from Jupyter notebook outputs or `lorem.mjs`) cannot be copied as static images and cannot be cross-referenced from nucleus-docs. Key result figures in a module spec should be static PNG files with explicit `:name: fig:something` labels in `main.md`. Only figures with `:name:` labels are reachable via `xref:<devnote-key>#fig:something` in spec pages.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ The documentation organizes content into three parallel hierarchies under `docs/
 
 The site TOC is defined entirely in `myst.yml`. When adding a new page, you must add it to the `toc:` section. Child pages that should not appear directly in the sidebar use `hidden: true`. The file `site.yml` holds site-wide settings (license, nav links, theme) that `myst.yml` extends.
 
-**Adding a module spec requires two table-of-contents updates, not one.** In addition to the `myst.yml` TOC entry, add a row to the table in `docs/modules/modules-main.md`. The table columns are `Module Class | Specification | Validation` — fill in the class name (e.g. `Detector`), a relative link to the spec (e.g. `[LacI-IPTG](./detector-laci_iptg/spec.md)`), and the validation star rating (use `★` for validated, `☆` for unvalidated, following the existing rows as a guide). Missing this step leaves the module off the main module index page.
+**Adding a module spec requires two table-of-contents updates, not one.** In addition to the `myst.yml` TOC entry, add a row to the table in `docs/modules/modules-main.md`. The table columns are `Module Class | Specification | Validation` — fill in the class name (e.g. `Detector`), a relative link to the spec (e.g. `[LacI-IPTG](./detector-laci_iptg/spec.md)`), and the validation star rating (use ★ to ★★★ following the validation key at the top of `modules-main.md`: ★ = preliminary/DevNote only, ★★ = validated in cells or in vitro, ★★★ = frequently used). Missing this step leaves the module off the main module index page.
 
 ### Templates
 
@@ -202,9 +202,12 @@ When migrating content from Notion markdown exports:
 - **Units in table column headers**: Use parentheses, not brackets (e.g., `MW (g/mol)` not `MW [g/mol]`).
 - **Data discrepancies (including concentrations)**: Source content sometimes carries internally inconsistent or unverified values — a value in the body text that conflicts with a figure caption, or a stock concentration that does not match the stated final concentration. Do not silently correct or copy these — add a `:::{warning}` block adjacent to the affected content that names the specific discrepancy, shows the conflicting values, states the most likely interpretation, and instructs the reviewer to verify before bench use. For reaction tables specifically, verify that `stock concentration × volume / total volume = stated final concentration` for every reagent row, and flag any row that fails.
 - **Scope boundary — spec vs. process**: Protocol steps, materials tables, and imaging conditions from a DevNote belong in a future Process page, not the module spec. The spec covers what the module is, its genetic designs, and expected performance. If protocol-level content appears in the DevNote, note it with a `<!-- TODO: move to process page -->` comment rather than migrating it into the spec.
-- **DevNote migration start — read `curvenote.yml` first**: `curvenote.yml` is the single best starting point for a DevNote migration. It contains the DOI, project ID, author list (with ORCIDs and affiliations), figure sources, and download files. Read it before `main.md` to orient to the content.
 - **DevNote figures — use static PNGs with `:name:` labels**: Computed figures (e.g. from Jupyter notebook outputs or `lorem.mjs`) cannot be copied as static images and cannot be cross-referenced from nucleus-docs. Key result figures in a module spec should be static PNG files with explicit `:name: fig:something` labels in `main.md`. Only figures with `:name:` labels are reachable via `xref:<devnote-key>#fig:something` in spec pages.
 - **Bare DOI citations from Curvenote**: Curvenote DevNotes use `[](10.xxxx/xxxxx)` as a shorthand DOI citation. This resolves as a local file path in the nucleus-docs MyST build and causes a link-checker error. Always replace with a full markdown link on migration: `[Author et al., year](https://doi.org/10.xxxx/xxxxx)`. Check for bare `[](` patterns with `grep -n '\[\](' <file>` before committing a migrated spec.
+
+### DevNote migration
+
+**Read `curvenote.yml` first.** `curvenote.yml` is the single best starting point for a DevNote migration. It contains the DOI, project ID, author list (with ORCIDs and affiliations), figure sources, and download files. Read it before `main.md` to orient to the content.
 
 ### External references
 


### PR DESCRIPTION
## Summary

Documents conventions surfaced during recent migrations (LacI-IPTG, responder-atc-ivhsl, Pierce660, Cx43 DevNote) that were previously undocumented and kept recurring. Covers all items from the issue body (#1–6) and all comment items (#7–14).

### DNA repo section
- **#1** `gh api` fallback commands when `~/src/nucleus-eng/DNA` is not on the machine
- **#3 + #9** When a construct is missing from `nucleus-eng/DNA`: add `:::{attention}` block naming the gap and legacy repo (`bnext-bio/nucleus`, do not link); DevNote constructs should be submitted to `nucleus-eng/DNA` before or alongside migration

### Content model section
- **#6** Manufacturer PDFs must not be committed — add `<!-- TODO -->` on download card until a hosting convention exists
- **#4** Adding a module spec requires a row in `docs/modules/modules-main.md` (Module Class | Specification | Validation) in addition to the `myst.yml` TOC entry

### Templates section
- **#5** When migrating into a pre-created stub, run `git ls-files` and `git rm` any template placeholder images before committing

### MyST syntax conventions section
- **#12** Tab-set fence depth: `{tab-set}` = 5 colons, `{tab-item}` = 4, inner admonitions = 3

### Notion migration gotchas section
- **#2** Concentration discrepancy check: verify `stock × vol / total = final`; add `:::{warning}` if mismatch
- **#11** Scope boundary: protocol steps/materials/imaging → future Process page, not the spec
- **#10** Read `curvenote.yml` first in a DevNote migration (DOI, authors, figure sources)
- **#7 + #8** DevNote hero figures must be static PNGs with `:name: fig:x` labels; computed outputs are not xref-able
- **#14** Replace bare `[](10.x/x)` DOI citations with full `[Author, year](https://doi.org/...)` links; grep `\[\](` before committing

### .gitignore
- **#13** Add `**/resources/[0-9][0-9]-*/` to cover numbered DevNote export folders (generalizes the per-module `09-cx43_cell` pattern)

## Test plan

- [x] `vale CLAUDE.md` → 0 errors, 0 warnings
- [x] No content `.md` files changed (only CLAUDE.md and .gitignore)
- [ ] Manual review: each of the 14 items matches the intent in the issue

## Also folds in issue #62 (migration learnings)

This branch additionally lands the actionable recommendations from #62 (the ClpXP/IV-HSL/TetR migration learnings):

- **rec 1** — file-placement table row for module raw assets (`docs/modules/<name>/resources/`)
- **rec 2** — secondary-figure `::::{hint}` dropdown convention (MyST syntax section)
- **rec 3** — system-context figures belong in `## Cells`, not `# Overview` (MyST syntax section)
- **rec 4** — the existing "Concentration discrepancies" bullet generalized to any internally inconsistent/unverified value

rec 5 (module template forked from the authored `## Cytosols`/`## Cells` convention) is **out of scope** here — it needs an architecture decision and is tracked separately.

Closes #87
Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)