### PR TITLE
fix(scripts): filter cached Sigma-Aldrich HTTP/2 false positives by URL

### DIFF
--- a/scripts/check-links.py
+++ b/scripts/check-links.py
@@ -67,12 +67,28 @@ def main():
     genuine_errors = {}
     filtered_count = 0
 
-    for filepath, entries in report.get("error_map", {}).items():
+    error_map = report.get("error_map", {})
+
+    # A vendor URL that produced the HTTP/2 protocol error anywhere in the report
+    # is a known crawler-block false positive. Newer lychee dedupes repeated URLs
+    # within a run and reports the repeats from cache with the HTTP/2 detail
+    # stripped (status collapses to a generic "Error (cached)"), so match by URL
+    # — not per-entry text — to catch those cached repeats too. Genuine dead
+    # links (404/DNS) never produce an HTTP/2 error, so they are never added here
+    # and stay reported.
+    http2_fp_urls = {
+        entry.get("url", "")
+        for entries in error_map.values()
+        for entry in entries
+        if is_http2_false_positive(
+            entry.get("url", ""), entry.get("status", {}).get("text", "")
+        )
+    }
+
+    for filepath, entries in error_map.items():
         real = []
         for entry in entries:
-            url = entry.get("url", "")
-            text = entry.get("status", {}).get("text", "")
-            if is_http2_false_positive(url, text):
+            if entry.get("url", "") in http2_fp_urls:
                 filtered_count += 1
             else:
                 real.append(entry)


### PR DESCRIPTION
## Summary

`Check Links` CI has been red on every PR since ~2026-06-08, reporting `sigmaaldrich.com` product URLs (in `prep-consumables/main.md`, `lysis-sonication/main.md`) as genuine dead links. They are **crawler-block false positives** the script is meant to filter — Sigma-Aldrich kills HTTP/2 connections at the protocol level (see `.lychee.toml` / CLAUDE.md).

## Root cause

CI installs lychee `latest`; newer lychee **dedupes repeated URLs within a run**. It makes one live request — that occurrence keeps the full `"...HTTP/2 protocol error..."` status text — and reports the *other* occurrences from its in-memory cache, where the detail collapses to a generic `Error (cached)`.

`check-links.py` matched the false positive on the `"HTTP/2 protocol error"` substring **per entry**, so the live occurrence was filtered (the "57 filtered" in the log) but the cached repeats leaked (the "6 genuine"). E.g. `sial/m2670` appears in 3 files → 1 filtered, 2 leaked. It's invisible on older local lychee (0.24.2), which re-requests every occurrence.

## Fix

Seed a set of URLs that produced the HTTP/2 error *anywhere* in the report, then filter **every** occurrence of those URLs — regardless of the (possibly cached) per-entry text. Genuine dead links (404/DNS) never produce an HTTP/2 error, so they're never seeded and stay reported. Reuses the existing `is_http2_false_positive` helper; no config or workflow changes.

## Verification

- **Synthetic report:** a 3×-repeated Sigma URL (1 live + 2 `Error (cached)`) is fully filtered, while a genuine `404` Sigma URL is still reported. ✅
- **Local smoke run:** `python3 scripts/check-links.py docs/` → exit 0, 202/236 OK. ✅
- **End-to-end:** the `Check Links` job on this PR (lychee `latest`) is the authoritative check — it exercises the cached-repeat path.

Unblocks `Check Links` for all open PRs (including #135).

🤖 Generated with [Claude Code](https://claude.com/claude-code)