### PR TITLE
feat(#81): fold column prep inline into purify-proteins-grav-column

### DIFF
--- a/docs/processes/make-protein/purify-proteins-grav-column/main.md
+++ b/docs/processes/make-protein/purify-proteins-grav-column/main.md
@@ -16,12 +16,21 @@ Please read this section carefully. It contains important notes, resources, and 
 :icon: false
 
 - [Prepare Protein Purification Buffers and Media](../prep-consumables/main.md)
-- Prepare Columns
 - [Lyse Bacteria by Sonication](../lysis-sonication/main.md)
 
 ::::::
+:::{note} References
+:class: dropdown
+:icon: false
+
+- [Cell-free translation reconstituted with purified components](https://doi.org/10.1038/90802)
+- [A Simple, Robust, and Low-Cost Method To Produce the PURE Cell-Free System](https://doi.org/10.1021/acssynbio.8b00427)
+- [OnePot PURE Cell-Free System](https://dx.doi.org/10.3791/62625)
+
+:::
 
 :::::::
+
 
 # Materials and Equipment
 
@@ -47,21 +56,38 @@ Please read this section carefully. It contains important notes, resources, and 
 
 # Protocol
 
+## Prepare Columns
+
 - [ ] **Prepare buffers:** Prepare the following buffers; chill at 4°C:
-  - [ ] 50 mL Wash Buffer per sample.
-  - [ ] 6 mL Elution Buffer per sample.
-- [ ] **Assemble columns:** Assemble one (1) gravity column (2 mL resin bed) per sample.
-- [ ] **Wash columns:** Wash each column with 5 CV of Ultrapure water. For this protocol, we will assume you are using a 2 mL resin bed.
+	- [ ] 50 mL Wash Buffer per sample. 
+	- [ ] 6 mL Elution Buffer per sample.
+- [ ] **Assemble columns:** Prepare one (1) gravity column per sample: 
+	- [ ] Cut the tips off the columns with scissors or a razor blade.
+	- [ ] Pack a filter into the bottom of each column (we use the back end of a cell spreader).
+
+:::{hint} Note: columns have ridges!
+:class: dropdown
+
+The filter needs to be pushed past two circular ridges on the inside of the column — one ~2 cm from the opening and another ~5 cm further down.
+
+:::
+
+- [ ] **Wash empty columns:** Clamp the columns to a lab stand with a large beaker (≥ 500 mL) underneath to capture flowthrough. Wash each column and filter with 10 mL Ultrapure water.
+- [ ] **Load and equilibrate resin:**
+	- [ ] Resuspend the Ni²⁺ resin (50% v/v slurry) by shaking.
+	- [ ] Add 2 mL resin slurry (≈ 1 mL settled bed) to each column by pipette.
+	- [ ] Equilibrate each column with ≥ 10 CV (10 mL) cold Wash Buffer (4°C); discard the flowthrough.
 
 :::{hint} Note: "CV" = Column Volume
 :class: dropdown
 
-One "Column Volume" is equal to the volume of affinity resin in your column. For example, "wash with 5 CV of Wash Buffer" means that for 2 mL of resin, wash with 10 mL of Wash Buffer. Specifying buffer volumes by CVs allows the user to increase or decrease the scale of the purification and still use the same protocol.
+One "Column Volume" (CV) is the settled resin bed volume. Our 2 mL of 50% v/v resin slurry gives a ~1 mL bed, so 1 CV = 1 mL (e.g., 10 CV = 10 mL). Specifying buffer volumes by CVs lets you scale the purification up or down and use the same protocol.
 
 :::
 
-- [ ] **Equilibrate columns:** Equilibrate each column with ≥ 5 CV (10 mL) cold Wash Buffer.
-- [ ] **Load lysate:** Load up to 5 CV (10 mL) clarified lysate per column. Optionally capture flowthrough for later analysis.
+## Purify Protein
+
+- [ ] **Load lysate:** Load up to 10 CV (10 mL) clarified lysate per column. Optionally capture flowthrough for later analysis.
 
 :::{hint} Note: if you have >10 mL lysate, load in tranches.
 :class: dropdown
@@ -70,8 +96,20 @@ If you have more than 10 mL of clarified lysate, you can load your sample in tra
 
 :::
 
-- [ ] **Wash:** Wash column with ≥ 5 CV (10 mL) cold Wash Buffer. Allow buffer to flow through. Optionally capture flowthrough for later analysis.
-- [ ] **Elute:** Elute sample with 3 CV (6 mL) cold Elution Buffer. Capture flow through in 15 mL centrifuge tube.
+- [ ] **Wash:** Wash each column with ≥ 10 CV (10 mL) cold Wash Buffer. Allow buffer to flow through. Optionally capture flowthrough for later analysis.
+- [ ] **Elute:** Elute sample with 6 CV (6 mL) cold Elution Buffer. Capture flowthrough in a 15 mL centrifuge tube.
+
+## Storing Columns
+
+- [ ] **Short-term (up to 48 hrs):** Seal each column with a cap and bung and store at 4°C.
+- [ ] **Long-term / reuse:** To store columns longer than 48 hrs — or to save used columns for later reuse — store them in 20% EtOH. Wash the column in Wash Buffer (as above), then with 10 CV (10 mL) Ultrapure water to remove salts. Fill the column with 20% EtOH, seal the bung and lid with parafilm, and store at 4°C.
+
+:::{hint} Note: why store in EtOH?
+:class: dropdown
+
+Packed and loaded columns can harbor bacterial growth, even at 4°C. Storing in 20% EtOH prevents this for columns you will not use within 48 hrs, or that you want to reuse later.
+
+:::
 
 # Downloads
 
@@ -90,12 +128,6 @@ If you have more than 10 mL of clarified lysate, you can load your sample in tra
 :::
 
 ::::
-
-# References
-
-- [Cell-free translation reconstituted with purified components](https://doi.org/10.1038/90802)
-- [A Simple, Robust, and Low-Cost Method To Produce the PURE Cell-Free System](https://doi.org/10.1021/acssynbio.8b00427)
-- [OnePot PURE Cell-Free System](https://dx.doi.org/10.3791/62625)
 
 # Acknowledgments
 


### PR DESCRIPTION
Closes #81.

## Problem

Column preparation (~15 min: cut tips, pack filter, wash empty columns, load + equilibrate Ni resin) is done the same day as purification, but the page listed it only as a **dangling "Prepare Columns" prerequisite** — a plain-text item with no backing page. The detailed steps lived solely on a never-migrated Notion subprotocol, so the workflow wasn't self-contained.

## Changes

- **Restructure `# Protocol`** (was a flat checklist) into `## Prepare Columns` / `## Purify Protein` / `## Storing Columns`.
- **`## Prepare Columns`** authored from the source subprotocol: assemble (cut tips, pack filter + "columns have ridges" hint), wash empty columns (10 mL water, clamp + beaker), load + equilibrate Ni²⁺ resin.
- **`## Storing Columns`** (new): short-term (cap + bung, 4 °C, ≤48 hrs) and long-term/reuse (20 % EtOH, full steps + "why EtOH" hint).
- **Corrected the CV basis.** The resin is a 50 % v/v slurry, so 2 mL slurry → ~1 mL settled bed (CV = 1 mL). The mL volumes (validated) are unchanged; the CV *counts* were relabeled to the true bed (5→10, 3→6 CV), and the "CV = Column Volume" note rewritten to match.
- **Removed** the dead "Prepare Columns" reference from the prerequisite dropdown (nothing linked to it).

`prep-consumables` was checked and needs no change (no column content). No new BOM rows: the prep's generic equipment (scissors, cell spreader, filter, lab stand, beaker, cap/bung) has no part numbers in the source.

## QA

- `check-dropdowns`, `check-bom-labels` ✅
- Vale 0 errors; `codespell` clean
- `build-protocols.py --extract-only` regenerates the bench checklist with all three sections and the corrected volumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)