### PR TITLE
feat(#113): author BOMs + inline buffer/media recipes for make-ribosomes & make-trna

### DIFF
--- a/docs/processes/make-ribosomes/main.md
+++ b/docs/processes/make-ribosomes/main.md
@@ -48,7 +48,154 @@ Please read this section carefully. It contains important notes, resources, and 
 
 :::::::
 
+# Materials and Equipment
+
+:::{table} Bill of Materials
+:label: bom-make-ribosomes
+
+| Name                                          | Category    | Product                                                                                                                                                              | Manufacturer       | Part #      | Price   | Storage     | Link                                                                                                                                                                                 |
+| --------------------------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ----------- | ------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| HEPES                                         | Salts       | HEPES, Crystalline Powder, ≥99.5% (titration), Poly bottle                                                                                                           | Sigma-Aldrich      | H3375-500G  | $431    | 4°C to 30°C | [link](https://www.sigmaaldrich.com/US/en/product/sigma/h3375)                                                                                                                       |
+| Ammonium Chloride                             | Salts       | Ammonium chloride, ACS reagent, ≥99.5%                                                                                                                               | Sigma-Aldrich      | 213330-500G | $73.50  | 4°C to 30°C | [link](https://www.sigmaaldrich.com/US/en/product/sigald/213330)                                                                                                                     |
+| Ammonium Sulfate                              | Salts       | Ammonium sulfate,BioXtra, ≥99.0%                                                                                                                                     | Sigma-Aldrich      | A2939-1KG   | $188.00 | 4°C to 30°C | [link](https://www.sigmaaldrich.com/US/en/product/sial/a2939)                                                                                                                        |
+| Potassium Chloride                            | Salts       | Potassium Chloride, ACS reagent, 99.0-100.5%                                                                                                                         | Sigma-Aldrich      | P3911-1KG   | $146.00 | 4°C to 30°C | [link](https://www.sigmaaldrich.com/US/en/product/sigald/p3911)                                                                                                                      |
+| Magnesium Acetate                             | Salts       | Magnesium acetate tetrahydrate                                                                                                                                       | Sigma-Aldrich      | M0631-100G  | $34.80  | 4°C to 30°C | [link](https://www.sigmaaldrich.com/US/en/product/sigald/m0631)                                                                                                                      |
+| Potassium Hydroxide                           | Salts       | Potassium hydroxide - ACS reagent, ≥85%, pellets                                                                                                                     | Sigma-Aldrich      | 221473-1KG  | $99.90  | 4°C to 30°C | [link](https://www.sigmaaldrich.com/US/en/product/sigald/221473)                                                                                                                     |
+| Sodium Chloride                               | Salts       | Sodium Chloride, Redi-Dri™, anhydrous, free-flowing, ACS, ≥99%                                                                                                       | Sigma-Aldrich      | 746398-1KG  | $133.00 | 4°C to 30°C | [link](https://www.sigmaaldrich.com/US/en/product/sigald/746398)                                                                                                                     |
+| Sodium Hydroxide (pellets)                    | Salts       | Sodium hydroxide, ACS Reagent Grade, Pellets, ≥97.0%, Poly bottle                                                                                                    | Sigma-Aldrich      | 221465-1KG  | $137.00 | 4°C to 30°C | [link](https://www.sigmaaldrich.com/US/en/product/sigald/221465)                                                                                                                     |
+| Acetic Acid (glacial)                         | Supplements | Acetic Acid, Glacial (Certified ACS), Fisher Chemical                                                                                                                | Fisher Scientific  | A38-212     | $458    | 4°C to 30°C | [link](https://www.fishersci.ca/shop/products/acetic-acid-glacial-certified-acs-fisher-chemical-9/A38212)                                                                            |
+| Sucrose                                       | Supplements | Sucrose, bioultra, for molecular biology, ≥99.5% (HPLC)                                                                                                              | Sigma-Aldrich      | 84097-1KG   | $170.00 | 4°C to 30°C | [link](https://www.sigmaaldrich.com/US/en/product/sigma/84097)                                                                                                                       |
+| TCEP                                          | Supplements | Thermo Scientific, Bond-Breaker® Tris[2-Carboxyethyl]phosphine Neutral Solution (TCEP), Application=Water-Soluble Reducing Agent, Molecular Weight=286.65, Size=5 mL | Thermo Scientific  | 77720       | $175.65 | 4°C to 30°C | [link](https://www.thermofisher.com/order/catalog/product/77720)                                                                                                                     |
+| Ethanol                                       | Supplements | Ethanol, HPLC/Spectrophotometric Grade, Liquid, ≥99.5%, Glass bottle, 200 Proof                                                                                      | Sigma-Aldrich      | 459828-4L   | $493.00 | 4°C to 30°C | [link](https://www.sigmaaldrich.com/US/en/product/sigald/459828)                                                                                                                     |
+| Laemmli Buffer (6x)                           | Supplements | Laemmli SDS-Sample Buffer (6x, Reducing)                                                                                                                             | Boston BioProducts | BP-111R     | $42.00  | 4°C to 30°C | [link](https://www.bostonbioproducts.com/products/laemmli-sds-sample-buffer-6x-reducing-bp-111r)                                                                                     |
+| LB                                            | Media       | Luria Broth (Miller's LB Broth), Non-Sterile, pH 6.8-7.2, Molecular Biology Grade, Powder                                                                            | Sigma-Aldrich      | L3522-1KG   | $221    | 4°C to 30°C | [link](https://www.sigmaaldrich.com/US/en/product/sigma/l3522)                                                                                                                       |
+| A19 *E. coli*                                 | Strains     | A19 (RNase I mutant)                                                                                                                                                 | CGSC               | 5997        | $130.00 | -80°C       | [link](https://ecgrc.net/index.php/product/a19/)                                                                                                                                     |
+| Culture tubes (14 mL)                         | Consumables | 14mL Culture Tube and Dual Cap, PP, Sterile                                                                                                                          | CELLTREAT          | 230439      | $190.00 | 4°C to 30°C | [link](https://www.celltreat.com/product/230439/)                                                                                                                                    |
+| 2 L baffled Erlenmeyer flasks                 | Consumables | PYREX® 2L Delong Shaker Erlenmeyer Flask with Baffles                                                                                                                | Corning            | 4444-2L     | $96.44  | 4°C to 30°C | [link](https://ecatalog.corning.com/life-sciences/b2c/US/en/Bioprocess-and-Scale-up/Erlenmeyer-Flasks/Erlenmeyer-Flasks%2C-Glass/PYREX%C2%AE-Flask-with-Baffles/p/pyrexFlaskBaffled) |
+| 1 L centrifuge bottles                        | Consumables | Thermo Scientific™ # Fiberlite 1000mL Bottles                                                                                                                        | Thermo Scientific  | 010-1491    | $326.84 | 4°C to 30°C | [link](https://www.thermofisher.com/order/catalog/product/010-1491)                                                                                                                  |
+| 0.22 µm syringe filters                       | Consumables | PES Syringe Filter, 0.22µm, 30mm, Sterile                                                                                                                            | CELLTREAT          | 229747      | $84.00  | 4°C to 30°C | [link](https://www.celltreat.com/product/229747/)                                                                                                                                    |
+| Butyl HIC columns (5 mL)                      | Columns     | HiTrap Butyl HP Column                                                                                                                                               | Cytiva             | 28-4110-05  | $679.00 | 4°C to 30°C | [link](https://www.cytivalifesciences.com/en/us/products/items/hitrap-butyl-hp-p-05631?selectedProduct=28411005)                                                                     |
+| 15 mL centrifuge tubes                        | Consumables | Corning® 15 mL PP Centrifuge Tubes, Rack Packed with CentriStar™ Cap, Sterile, 50/Rack, 500/Case                                                                     | Corning            | 430790      | $230.44 | 4°C to 30°C | [link](https://ecatalog.corning.com/life-sciences/b2b/UK/en/Liquid-Handling/Tubes%2C-Liquid-Handling/Centrifuge-Tubes/Corning%C2%AE-15mL-Centrifuge-Tubes/p/430790)                  |
+| Polycarbonate ultracentrifuge bottles (70 mL) | Consumables | 70 mL Polycarbonate Bottle Assembly, 38 x 102mm - 6Pk                                                                                                                | Beckman Coulter    | 355622      | $687.60 | 4°C to 30°C | [link](https://www.beckman.com/supplies/tubes-and-bottles/bottles/355622)                                                                                                            |
+| 100 kDa centrifugal filter                    | Consumables | Amicon® Ultra Centrifugal Filter, 100 kDa MWCO                                                                                                                       | EMD Millipore      | UFC910008   | $141.00 | 4°C to 30°C | [link](https://www.sigmaaldrich.com/US/en/product/mm/ufc9100)                                                                                                                        |
+| Tris-Glycine 4–20% gels                       | Consumables | 4–20% Mini-PROTEAN® TGX™ Precast Protein Gels, 10-well, 50 µL                                                                                                        | BioRad             | 4561094     | $153.00 | 1°C to 4°C  | [link](https://www.bio-rad.com/en-us/sku/4561094-4-20-mini-protean-tgx-precast-protein-gels-10-well-50-ul?ID=4561094)                                                                |
+
+:::
+
 # Protocol
+
+## Prepare Stock Buffers
+
+- [ ] Make the following stock solutions. Use ultrapure water (18.2 MΩ, e.g., Milli-Q) and keep everything RNase-free.
+
+| **Stocks**         | Final Concentration (mM) | MW (g/mol) | Mass to add (g) | Final Vol (mL) | Storage (°C) |
+| ------------------ | ------------------------ | ---------- | --------------- | -------------- | ------------ |
+| HEPES-KOH (pH 7.6) | 1000                     | 238.3      | 238.3           | 1000           | room temp    |
+| Ammonium Chloride  | 1000                     | 53.49      | 53.49           | 1000           | room temp    |
+| Potassium Chloride | 1000                     | 74.55      | 74.55           | 1000           | room temp    |
+| Magnesium Acetate  | 1000                     | 214.45     | 214.45          | 1000           | room temp    |
+| Sodium Hydroxide   | 500                      | 40.00      | 20              | 1000           | room temp    |
+
+- [ ] Adjust the pH of HEPES-KOH to 7.6 with Potassium Hydroxide.
+- [ ] Prepare Sodium Hydroxide (0.5 M) from pellets (used to clean the HIC column).
+
+:::{hint} Note: components added dry or purchased
+:class: dropdown
+
+Ammonium sulfate and sucrose are **added dry** directly to the buffers (masses given in each recipe below), not prepared as stock solutions. TCEP is used from a purchased **0.5 M (500 mM)** neutral stock (Bond-Breaker) and added fresh on the day of use.
+
+:::
+
+## Prepare Stable Buffers
+
+Make these buffers *in advance* and store at 4°C. Add all components **except TCEP**, which you must add fresh on the day of use.
+
+- [ ] **Ribosome Lysis Buffer** — used to resuspend the cell pellet for sonication.
+
+| Reagent            | Final Concentration (mM) | Stock Concentration (mM) | Volume to Add (mL) |
+| ------------------ | ------------------------ | ------------------------ | ------------------ |
+| HEPES-KOH (pH 7.6) | 10                       | 1000                     | 15                 |
+| Magnesium Acetate  | 10                       | 1000                     | 15                 |
+| Potassium Chloride | 50                       | 1000                     | 75                 |
+| TCEP               | 1                        | 500                      | 3                  |
+| Ultrapure water    | —                        | —                        | 1392               |
+| **Total**          |                          |                          | **1500**           |
+
+- [ ] **Ribosome Salting Out Buffer** — added 1:1 to clarified lysate to bring ammonium sulfate to 1.5 M and precipitate contaminants.
+
+| Reagent            | Final Concentration (mM) | Stock Concentration (mM) | Volume to Add (mL) |
+| ------------------ | ------------------------ | ------------------------ | ------------------ |
+| Ammonium Sulfate   | 3000                     | n/a (dry)                | 198.21 g           |
+| HEPES-KOH (pH 7.6) | 10                       | 1000                     | 5                  |
+| Magnesium Acetate  | 10                       | 1000                     | 5                  |
+| Potassium Chloride | 50                       | 1000                     | 25                 |
+| TCEP               | 1                        | 500                      | 1                  |
+| Ultrapure water    | —                        | —                        | ~265.8             |
+| **Total**          |                          |                          | **500**            |
+
+- [ ] **Ribosome Wash Buffer** — HIC running/wash buffer; high ammonium sulfate drives hydrophobic binding.
+
+| Reagent            | Final Concentration (mM) | Stock Concentration (mM) | Volume to Add (mL) |
+| ------------------ | ------------------------ | ------------------------ | ------------------ |
+| Ammonium Sulfate   | 1500                     | n/a (dry)                | 396.42 g           |
+| HEPES-KOH (pH 7.6) | 20                       | 1000                     | 40                 |
+| Magnesium Acetate  | 10                       | 1000                     | 20                 |
+| TCEP               | 1                        | 500                      | 4                  |
+| Ultrapure water    | —                        | —                        | ~1539.6            |
+| **Total**          |                          |                          | **2000**           |
+
+- [ ] **Ribosome Elution Buffer** — HIC elution buffer; low salt releases bound ribosomes.
+
+| Reagent            | Final Concentration (mM) | Stock Concentration (mM) | Volume to Add (mL) |
+| ------------------ | ------------------------ | ------------------------ | ------------------ |
+| HEPES-KOH (pH 7.6) | 20                       | 1000                     | 20                 |
+| Magnesium Acetate  | 10                       | 1000                     | 10                 |
+| TCEP               | 1                        | 500                      | 2                  |
+| Ultrapure water    | —                        | —                        | 968                |
+| **Total**          |                          |                          | **1000**           |
+
+- [ ] **Cushion Buffer** — dense sucrose cushion through which ribosomes are pelleted during ultracentrifugation.
+
+| Reagent            | Final Concentration (mM) | Stock Concentration (mM) | Volume to Add (mL) |
+| ------------------ | ------------------------ | ------------------------ | ------------------ |
+| Sucrose            | 30% (w/v)                | n/a (dry)                | 300 g              |
+| HEPES-KOH (pH 7.6) | 20                       | 1000                     | 20                 |
+| Ammonium Chloride  | 30                       | 1000                     | 30                 |
+| Magnesium Acetate  | 10                       | 1000                     | 10                 |
+| TCEP               | 1                        | 500                      | 2                  |
+| Ultrapure water    | —                        | —                        | ~638               |
+| **Total**          |                          |                          | **1000**           |
+
+- [ ] **Ribosome Buffer** — final resuspension and storage buffer for purified ribosomes.
+
+| Reagent            | Final Concentration (mM) | Stock Concentration (mM) | Volume to Add (mL) |
+| ------------------ | ------------------------ | ------------------------ | ------------------ |
+| HEPES-KOH (pH 7.6) | 20                       | 1000                     | 10                 |
+| Magnesium Acetate  | 6                        | 1000                     | 3                  |
+| Potassium Chloride | 30                       | 1000                     | 15                 |
+| TCEP               | 1                        | 500                      | 1                  |
+| Ultrapure water    | —                        | —                        | 471                |
+| **Total**          |                          |                          | **500**            |
+
+## Prepare Working Buffers
+
+Make these column-cleaning solutions as needed for the FPLC step.
+
+- [ ] **Acetic Acid (0.1 M)** — prepared by diluting glacial acetic acid; used to clean the HIC column.
+
+| Reagent               | Final Concentration (mM) | Stock Concentration (mM) | Volume to Add (mL) |
+| --------------------- | ------------------------ | ------------------------ | ------------------ |
+| Acetic Acid (glacial) | 100                      | 17 400                   | 5.75               |
+| Ultrapure water       | —                        | —                        | 994.25             |
+| **Total**             |                          |                          | 1000               |
+
+- [ ] **Ethanol (20% v/v)** — used to wash and store the HIC column.
+
+| Reagent         | Final Concentration | Stock Concentration | Volume to Add (mL) |
+| --------------- | ------------------- | ------------------- | ------------------ |
+| Ethanol         | 20% (v/v)           | 100% (v/v)          | 200                |
+| Ultrapure water | —                   | —                   | 800                |
+| **Total**       |                     |                     | **1000**           |
 
 ## Cell culture
 
@@ -82,7 +229,7 @@ Optionally, you can work from individual colonies by streaking out your bacteria
 
 ## Lysis
 
-- [ ]  Resuspend (2-5) g cell pellet in 25 mL of Ribosome Lysis buffer & lyse cells using 130-watt probe sonicator (probe tip diameter: 6 mm) on ice with following parameters: 50% amplitude, 15s on/ 30s off for 2 minutes on-time. The amount of energy delivered via sonication will vary depending on the amount of cells resuspended.
+- [ ]  Resuspend (2-5) g cell pellet in 25 mL of Ribosome Lysis buffer & lyse cells using 130-watt probe sonicator (probe tip diameter: 6 mm) on ice with following parameters: 50% amplitude, 15s on/ 30s off for 2 min on-time. The amount of energy delivered via sonication will vary depending on the amount of cells resuspended.
 - [ ]  Clarify lysate by centrifugation at 16 000 rcf / 4°C / 10 min.
 - [ ]  Aspirate supernatant and measure volume. Add an equal volume of Salting Out buffer to adjust the concentration of ammonium sulfate to 1.5 M and mix well. Incubate at 4°C / 10 min.
 - [ ]  Remove precipitate by centrifugation at 16 000 rcf / 4°C / 10 min.
@@ -150,7 +297,7 @@ First, find the pellet. Next, wash the pellet by gently pipetting Ribosome Buffe
 
 - [ ]  Determine the ribosome concentration by measuring the absorbance at 260 nm at a 100x dilution in Ribosome Buffer. 10 units of A₂₆₀ from a 100x dilution corresponds to 23 µM of undiluted solution.
 - [ ]  Dilute to final stock of 10 µM. To adjust the concentration, dilute the ribosomes with ribosome buffer or concentrate further via centrifugation at 4000 rcf in a 100 kDa centrifugal filter at 4°C.
-- [ ]  Protein gel: dilute 10 µM sample by 4x (Add 2.5 µL of sample with 7.5 µL water) and mix with 10 µL of 4x Laemmli with BME loading buffer. Boil samples at 90°C for 10 minutes and load 5 µL and 2.5 µL onto 4-20% tris-glycine gel. Run gel at 200 V / 30-45 min or until the loading dye line reaches the bottom of the gel.
+- [ ]  Protein gel: dilute 10 µM sample by 4x (Add 2.5 µL of sample with 7.5 µL water) and mix with 2 µL of 6x Laemmli loading buffer. Boil samples at 90°C for 10 min and load 5 µL and 2.5 µL onto 4-20% tris-glycine gel. Run gel at 200 V / 30-45 min or until the loading dye line reaches the bottom of the gel.
 
 ## Storage
 
@@ -160,11 +307,16 @@ First, find the pellet. Next, wash the pellet by gently pipetting Ribosome Buffe
 
 :::::{card}
 :header: **Resources**
-::::{grid} 1 1 1 1
+::::{grid} 1 1 1 2
 
 :::{card}
 :header: **Lab-ready Protocol**
 {button}`download <generated/make-ribosomes-protocol.pdf>`
+:::
+
+:::{card}
+:header: **Bill of Materials**
+{button}`download <generated/make-ribosomes-bom.pdf>`
 :::
 
 ::::

--- a/docs/processes/make-trna/main.md
+++ b/docs/processes/make-trna/main.md
@@ -35,10 +35,6 @@ Please read this section carefully. It contains important notes, resources, and 
     - Corrosive to skin and eyes
     - Use appropriate PPE and handle under fume-hood
 
-- **Chloroform**
-    - Irritant, possible carcinogen
-    - Work in fume hood & appropriate gloves
-
 - **Ethanol**
     - Highly flammable, toxic, and irritant
     - Wear PPE, use in well-ventilated areas, and keep away from open flames
@@ -63,7 +59,84 @@ Please read this section carefully. It contains important notes, resources, and 
 
 :::::::
 
+# Materials and Equipment
+
+:::{table} Bill of Materials
+:label: bom-make-trna
+
+| Name                                          | Category    | Product                                                                                          | Manufacturer        | Part #      | Price   | Storage        | Link                                                                                                                                                                                                                                                                                             |
+| --------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------ | ------------------- | ----------- | ------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Sodium Acetate                                | Salts       | Sodium acetate trihydrate,ACS reagent, ≥99%                                                      | Sigma-Aldrich       | 236500-500G | $87.90  | 4°C to 30°C    | [link](https://www.sigmaaldrich.com/US/en/product/sigald/236500)                                                                                                                                                                                                                                 |
+| Magnesium Acetate                             | Salts       | Magnesium acetate tetrahydrate                                                                   | Sigma-Aldrich       | M0631-100G  | $34.80  | 4°C to 30°C    | [link](https://www.sigmaaldrich.com/US/en/product/sigald/m0631)                                                                                                                                                                                                                                  |
+| Sodium Chloride                               | Salts       | Sodium Chloride, Redi-Dri™, anhydrous, free-flowing, ACS, ≥99%                                   | Sigma-Aldrich       | 746398-1KG  | $133.00 | 4°C to 30°C    | [link](https://www.sigmaaldrich.com/US/en/product/sigald/746398)                                                                                                                                                                                                                                 |
+| Acetic Acid (glacial)                         | Salts       | Acetic Acid, Glacial (Certified ACS), Fisher Chemical                                            | Fisher Scientific   | A38-212     | $458    | 4°C to 30°C    | [link](https://www.fishersci.ca/shop/products/acetic-acid-glacial-certified-acs-fisher-chemical-9/A38212)                                                                                                                                                                                        |
+| Acid Phenol (pH 4.5)                          | Supplements | Invitrogen ambion Acid Phenol:Chloroform, pH 4.5 (with IAA, 125:24:1)                            | Fisher Scientific   | AM9722      | $313.65 | 2°C to 8°C     | [link](https://www.fishersci.com/shop/products/ambion-acid-phenol-chloroform-ph-4-5-with-iaa-125-24-1-2/AM9722)                                                                                                                                                                                  |
+| Isopropanol                                   | Supplements | BioReagent 2-Propanol, Molecular Biology Grade, Liquid, ≥99.5%                                   | Sigma-Aldrich       | I9516-1L    | $142.00 | 4°C to 30°C    | [link](https://www.sigmaaldrich.com/US/en/product/sigma/i9516)                                                                                                                                                                                                                                   |
+| Ethanol                                       | Supplements | Ethanol, HPLC/Spectrophotometric Grade, Liquid, ≥99.5%, Glass bottle, 200 Proof                  | Sigma-Aldrich       | 459828-4L   | $493.00 | 4°C to 30°C    | [link](https://www.sigmaaldrich.com/US/en/product/sigald/459828)                                                                                                                                                                                                                                 |
+| SYBR-Green stain                              | Supplements | Invitrogen sybr Green I Nucleic Acid Gel Stain 10,000x concentrate in DMSO                       | Fisher Scientific   | S7567       | $791.70 | -25°C to -15°C | [link](https://www.fishersci.com/shop/products/invitrogen-sybr-green-i-nucleic-acid-gel-stain-10-000x-concentrate-dmso-3/S7567)                                                                                                                                                                  |
+| 2x TBE-Urea sample buffer                     | Supplements | Invitrogen novex TBE-Urea Sample Buffer (2x)                                                     | Thermo Scientific   | LC6876      | $75.60  | 2°C to 8°C     | [link](https://www.thermofisher.com/order/catalog/product/LC6876)                                                                                                                                                                                                                                |
+| NEB low range ssRNA ladder                    | Supplements | Low Range ssRNA Ladder - 100 gel lanes                                                           | New England Biolabs | N0364S      | $87.00  | -25°C to -15°C | [link](https://www.neb.com/en-us/products/n0364-low-range-ssrna-ladder)                                                                                                                                                                                                                          |
+| LB                                            | Media       | Luria Broth (Miller's LB Broth), Non-Sterile, pH 6.8-7.2, Molecular Biology Grade, Powder        | Sigma-Aldrich       | L3522-1KG   | $221    | 4°C to 30°C    | [link](https://www.sigmaaldrich.com/US/en/product/sigma/l3522)                                                                                                                                                                                                                                   |
+| A19 *E. coli*                                 | Strains     | A19 (RNase I mutant)                                                                             | CGSC                | 5997        | $130.00 | -80°C          | [link](https://ecgrc.net/index.php/product/a19/)                                                                                                                                                                                                                                                 |
+| Culture tubes (14 mL)                         | Consumables | 14mL Culture Tube and Dual Cap, PP, Sterile                                                      | CELLTREAT           | 230439      | $190.00 | 4°C to 30°C    | [link](https://www.celltreat.com/product/230439/)                                                                                                                                                                                                                                                |
+| 2 L baffled Erlenmeyer flasks                 | Consumables | PYREX® 2L Delong Shaker Erlenmeyer Flask with Baffles                                            | Corning             | 4444-2L     | $96.44  | 4°C to 30°C    | [link](https://ecatalog.corning.com/life-sciences/b2c/US/en/Bioprocess-and-Scale-up/Erlenmeyer-Flasks/Erlenmeyer-Flasks%2C-Glass/PYREX%C2%AE-Flask-with-Baffles/p/pyrexFlaskBaffled)                                                                                                             |
+| 1 L centrifuge bottles                        | Consumables | Thermo Scientific™ # Fiberlite 1000mL Bottles                                                    | Thermo Scientific   | 010-1491    | $326.84 | 4°C to 30°C    | [link](https://www.thermofisher.com/order/catalog/product/010-1491)                                                                                                                                                                                                                              |
+| 50 mL centrifuge tubes                        | Consumables | Corning® 50 mL Polypropylene Centrifuge Tubes, Sterile, Racked, CentriStar™ Cap                  | Corning             | 430828      | $436.88 | 4°C to 30°C    | [link](https://ecatalog.corning.com/life-sciences/b2b/US/en/Liquid-Handling/Tubes%2C-Liquid-Handling/Centrifuge-Tubes/Corning%C2%AE-50-mL-Centrifuge-Tubes/p/430828)                                                                                                                             |
+| 15 mL centrifuge tubes                        | Consumables | Corning® 15 mL PP Centrifuge Tubes, Rack Packed with CentriStar™ Cap, Sterile, 50/Rack, 500/Case | Corning             | 430790      | $230.44 | 4°C to 30°C    | [link](https://ecatalog.corning.com/life-sciences/b2b/UK/en/Liquid-Handling/Tubes%2C-Liquid-Handling/Centrifuge-Tubes/Corning%C2%AE-15mL-Centrifuge-Tubes/p/430790)                                                                                                                              |
+| Slide-A-Lyzer G3 Dialysis Cassettes (3.5 kDa) | Consumables | Slide-A-Lyzer™ G3 Dialysis Cassettes, 3.5K MWCO                                                  | Thermo Scientific   | A52966      | $128.70 | 4°C to 30°C    | [link](https://www.thermofisher.com/order/catalog/product/A52966)                                                                                                                                                                                                                                |
+| Amicon Ultra 0.5 mL - 3 kDa                   | Consumables | Amicon® Ultra Centrifugal Filter, 3 kDa MWCO                                                     | Millipore Sigma     | UFC5003     | $63.00  | 4°C to 30°C    | [link](https://www.sigmaaldrich.com/US/en/product/mm/ufc5003)                                                                                                                                                                                                                                    |
+| TBE-Urea 10% gel                              | Consumables | 10% Mini-PROTEAN                                                                                 | Bio-Rad             | 4566033     | $41.00  | 2°C to 8°C     | [link](https://www.bio-rad.com/en-us/sku/4566033-10-mini-protean-tbe-urea-gel-10-well-30-ul?ID=4566033)                                                                                                                                                                                          |
+| glass serological pipettes                    | Consumables | PYREX® 10 mL Glass Serological Pipets, Sterile, Individually Paper/Plastic Wrapped, Plugged      | Corning             | 7077-10N    | $690.49 | 4°C to 30°C    | [link](https://ecatalog.corning.com/life-sciences/b2c/US/en/Glassware/Serological-Pipets%2C-Glass/PYREX%C2%AE-Disposable-Glass-Serological-Pipets%2C-Individually-Wrapped%2C-Sterile%2C-Plugged%2C-To-Deliver/p/pyrexPipetDisposableGlassSeriologicalIndividuallyWrappedSterilePluggedToDeliver) |
+
+:::
+
 # Protocol
+
+## Prepare Stock Buffers
+
+- [ ] Make the following stock solutions from solid. Use ultrapure water (18.2 MΩ, e.g., Milli-Q) and keep everything RNase-free.
+
+| **Stocks**        | Final Concentration (mM) | MW (g/mol) | Mass to add (g) | Final Vol (mL) | Storage (°C) |
+| ----------------- | ------------------------ | ---------- | --------------- | -------------- | ------------ |
+| Sodium Acetate    | 1000                     | 136.08     | 136.08          | 1000           | room temp    |
+| Magnesium Acetate | 1000                     | 214.46     | 214.46          | 1000           | room temp    |
+| NaCl (5 M)        | 5000                     | 58.44      | 292.2           | 1000           | room temp    |
+| NaCl (1 M)        | 1000                     | 58.44      | 11.688          | 200            | room temp    |
+
+## Prepare Buffers
+
+Adjust pH to 5.0 with glacial acetic acid, then bring to final volume with water.
+
+- [ ] **Extraction Buffer** — used to resuspend biomass for acid-phenol extraction.
+
+| Reagent               | Final Concentration (mM) | Stock Concentration (mM) | Volume to Add (mL) |
+| --------------------- | ------------------------ | ------------------------ | ------------------ |
+| Sodium Acetate        | 50                       | 1000                     | 50                 |
+| Magnesium Acetate     | 10                       | 1000                     | 10                 |
+| Acetic Acid (glacial) | —                        | —                        | to pH 5.0          |
+| Ultrapure water       | —                        | —                        | to 1000            |
+| **Total**             |                          |                          | **1000**           |
+
+- [ ] **NaOAc (300 mM, pH 5.0)** — used to dissolve the nucleic-acid pellet before DNA removal.
+
+| Reagent               | Final Concentration (mM) | Stock Concentration (mM) | Volume to Add (mL) |
+| --------------------- | ------------------------ | ------------------------ | ------------------ |
+| Sodium Acetate        | 300                      | 1000                     | 30                 |
+| Acetic Acid (glacial) | —                        | —                        | to pH 5.0          |
+| Ultrapure water       | —                        | —                        | to 100             |
+| **Total**             |                          |                          | **100**            |
+
+## Prepare Working Buffers
+
+Make this wash solution as needed; dilute from ~100% (200 proof) ethanol.
+
+- [ ] **Ethanol (70% v/v)** — used to wash nucleic-acid pellets during precipitation.
+
+| Reagent         | Final Concentration | Stock Concentration | Volume to Add (mL) |
+| --------------- | ------------------- | ------------------- | ------------------ |
+| Ethanol         | 70% (v/v)           | 100% (v/v)          | 700                |
+| Ultrapure water | —                   | —                   | 300                |
+| **Total**       |                     |                     | **1000**           |
 
 ## Cell culture
 
@@ -88,7 +161,7 @@ Optionally, you can work from individual colonies by streaking out your bacteria
 - [ ] Incubate back diluted cultures at 37°C / (225-250) rpm to mid-log phase (OD₆₀₀ between 0.6 and 0.8). This took us ~3 hrs.
 
 **Pellet, wash, and store cells.**
-- [ ] Fill 500 mL centrifuge bottles with culture. Balance centrifuge bottles against each other and pellet cultures at 16 000 rcf / 4°C / 10 min.
+- [ ] Fill 1 L centrifuge bottles with culture. Balance centrifuge bottles against each other and pellet cultures at 16 000 rcf / 4°C / 10 min.
 - [ ] Decant supernatant, add fresh culture, and repeat centrifugation as above, working through the remaining culture. You should end up with large pellets at the bottom of each centrifuge bottle.
 - [ ] Wash the pellets by resuspending in 500 mL cold (4°C) NaCl (0.9%) then pelleting again at 16 000 rcf / 4°C / 10 min.
 - [ ] Transfer pellets by spatula into a tared bag weigh and record the mass.
@@ -118,7 +191,7 @@ Optionally, you can work from individual colonies by streaking out your bacteria
 - [ ] Wash the pellet with EtOH (70%):
 	- [ ] Decant supernatant and wash nucleic acid pellet with 10 mL cold (-20°C) EtOH (70%).
     - [ ] Re-pellet nucleic acid pellet by centrifugation at 14 500 rcf / 25°C / 5 min.
-    - [ ] Decant the supernatant and allow the pellet to air dry for 10 minutes.
+    - [ ] Decant the supernatant and allow the pellet to air dry for 10 min.
 
 **Remove rRNA by precipitation:**
 - [ ] Resuspend each pellet into 15 mL of cold (4°C) NaCl (1 M) by vortexing or pipetting. Ensure the pellet is fully dissolved. Allow NaCl (1 M) solution to hydrate pellet for (10 - 15) min at room temperature to help the pellet dissolve.
@@ -149,7 +222,7 @@ Optionally, you can work from individual colonies by streaking out your bacteria
 We typically use dialysis cassettes rather than dialysis membranes for ease of use. Instructions below are for dialysis cassettes, but should work for either. Use membranes with a molecular weight cut off < 10 kDa (we use 3.5 kDa). See [# Slide-A-Lyzer™ G3 Dialysis Cassettes, 3.5K MWCO](https://www.thermofisher.com/order/catalog/product/A52966) for an example commercial dialysis cassette.
 :::
 
-- [ ] Hydrate the dialysis membrane: Remove the cassette from its protective pouch and immerse in nuclease-free water for 2 minutes.
+- [ ] Hydrate the dialysis membrane: Remove the cassette from its protective pouch and immerse in nuclease-free water for 2 min.
 - [ ] Add Sample:
 	- [ ] Open the cassette by twisting the cap counter-clockwise.
 	- [ ] Carefully pipette 1.5 mL of resuspended tRNAs into the cassette. Avoid puncturing the membrane!
@@ -219,11 +292,16 @@ If your samples appear as a smear on your gel, consider testing your input buffe
 
 :::::{card}
 :header: **Resources**
-::::{grid} 1 1 1 1
+::::{grid} 1 1 1 2
 
 :::{card}
 :header: **Lab-ready Protocol**
 {button}`download <generated/make-trna-protocol.pdf>`
+:::
+
+:::{card}
+:header: **Bill of Materials**
+{button}`download <generated/make-trna-bom.pdf>`
 :::
 
 ::::


### PR DESCRIPTION
Closes #113.

## What

The last two non-exempt wet-lab process pages had no Bill of Materials. This adds both BOMs and — since their buffers/media were referenced but undocumented — folds the recipes **inline** (Option C: single-consumer buffers live in the protocol that uses them; no separate prep page, no master list, matching the reuse-driven logic behind `prep-consumables`).

## make-ribosomes
- **Inline recipes** in `prep-consumables` format: stock solutions + 6 working buffers (Lysis, Salting Out, Wash, Elution, Cushion, Ribosome Buffer) + column-cleaning solutions (NaOH 0.5 M from pellets, Acetic Acid 0.1 M from glacial, EtOH 20%).
- **CV basis corrected**: resin is a 50 % v/v slurry, so 2 mL → ~1 mL settled bed (CV = 1 mL); mL volumes unchanged, CV counts relabeled, CV note rewritten.
- **`bom-make-ribosomes`** (24 rows) + BOM download card.
- Gel loading buffer switched to **6× Laemmli (reducing)**; BME dropped as redundant.

## make-trna
- **Inline recipes**: stock solutions + Extraction Buffer (1000 mL), NaOAc (300 mM, pH 5.0), EtOH 70%.
- **`bom-make-trna`** (21 rows) + BOM download card.
- **Chloroform dropped** from Hazardous Materials (not used in any step); standardized on **1 L centrifuge bottles**.

## Notes
- Buffer recipes migrated from the lab's canonical worksheet and verified against it (recipe-fidelity review).
- **Equipment intentionally excluded** from both BOMs — to be tracked as a separate effort (follow-up issue).
- Catalogued part numbers reused via `enrich-bom.py`; new vendor data hand-authored.

## QA
- `check-bom-labels`, `check-dropdowns` ✅
- Vale 0 errors/0 warnings; `codespell` clean
- `build-protocols.py --extract-only` regenerates both protocol + BOM artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)