### PR TITLE
Split Base Cytosol composition into component tabs (#130)

### DIFF
--- a/docs/modules/base-cytosol/spec.md
+++ b/docs/modules/base-cytosol/spec.md
@@ -26,7 +26,7 @@ Base Cytosol is assembled from four components — a protein mix (PMix), a small
 :::::{tab-set}
 
 ::::{tab-item} PMix
-The Protein Mix (PMix) contains all 36 PURE proteins at a total stock concentration of 15 µg/µL. Per-protein stock concentrations are shown below; see the [make-36pot](../../processes/make-36pot/main.md) and [make-1pot](../../processes/make-1pot/main.md) processes for preparation.
+The Protein Mix (PMix) contains all 36 PURE proteins at a total stock concentration of 15 µg/µL. Per-protein stock concentrations are shown below; see the [Make PMix](../../processes/make-36pot/main.md) and [Make OnePot Protein Mix](../../processes/make-1pot/main.md) processes for preparation.
 
 :::{table} Composition of the Protein Mix (PMix) at stock concentration. Source: make-36pot process.
 :label: comp-pmix
@@ -73,7 +73,7 @@ The Protein Mix (PMix) contains all 36 PURE proteins at a total stock concentrat
 ::::
 
 ::::{tab-item} SMix
-The Small Molecule Mix (SMix) contains the buffers, nucleotides, amino acids, stabilizers, and cofactors. Concentrations below are in the assembled SMix; see the [make-small-molecule-mix](../../processes/make-small-molecule-mix/main.md) process for preparation.
+The Small Molecule Mix (SMix) contains the buffers, nucleotides, amino acids, stabilizers, and cofactors. Concentrations below are in the assembled SMix; see the [Make SMix](../../processes/make-small-molecule-mix/main.md) process for preparation.
 
 :::{table} Composition of the Small Molecule Mix (SMix) at stock concentration. Source: make-small-molecule-mix process.
 :label: comp-smix
@@ -95,7 +95,7 @@ The Small Molecule Mix (SMix) contains the buffers, nucleotides, amino acids, st
 ::::
 
 ::::{tab-item} Ribosomes
-:::{table} Ribosome stock concentration. Source: make-ribosomes process.
+:::{table} Ribosome stock concentration. Source: [Make Ribosomes](../../processes/make-ribosomes/main.md) process.
 :label: comp-ribosomes
 | Component | Stock Concentration | Reaction Concentration |
 |-----------|---------------------|------------------------|
@@ -104,7 +104,7 @@ The Small Molecule Mix (SMix) contains the buffers, nucleotides, amino acids, st
 ::::
 
 ::::{tab-item} tRNA
-:::{table} tRNA stock concentration. Source: make-trna process.
+:::{table} tRNA stock concentration. Source: [Make tRNAs](../../processes/make-trna/main.md) process.
 :label: comp-trna
 | Component | Stock Concentration | Reaction Concentration |
 |-----------|---------------------|------------------------|

--- a/docs/modules/base-cytosol/spec.md
+++ b/docs/modules/base-cytosol/spec.md
@@ -8,35 +8,118 @@ site:
 
 # Overview
 
-A molecular system with a defined set of components including T7 RNA Polymerase, ribosomes, and tRNA capable of transcription and translation. Base Cytosol builds on the [PURE system](https://doi.org/10.1038/90802), and is optimized for integration and extension. The Base Cell is formed by encapsulating Base Cytosol in a liposome.  
+A molecular system with a defined set of components including T7 RNA Polymerase, ribosomes, and tRNA capable of transcription and translation. Base Cytosol builds on the [PURE system](https://doi.org/10.1038/90802), and is optimized for integration and extension. The Base Cell is formed by encapsulating Base Cytosol in a liposome.
 
-:::::{tab-set}
+Plasmid designs for the PURE proteins are maintained as pET28a expression vectors in the [DNA Distribution](https://github.com/nucleus-eng/DNA/tree/main/PURE/expression) repository.
 
-::::{tab-item} Schematic
 :::{figure} schematic.png
 :width: 100%
 :align: center
 
-Schematic of components in Cytosol and their function. Figure by [Ganesh, R. B. & Maerkl, S. J.](https://doi.org/10.1101/2024.04.03.587879) used under CC-BY-4.0 / cropped from original with numerical annotations removed.
+Schematic of components in Cytosol and their function. Figure by [Ganesh and Maerkl, 2024](https://doi.org/10.1101/2024.04.03.587879) used under CC-BY-4.0 / cropped from original with numerical annotations removed.
 :::
-::::
-
-::::{tab-item} Designs
-
-Plasmid designs are included in the documentation of the [DNA Distribution](../../dna-distro.md).
-
-::::
-:::::
 
 ## Reference Composition
 
-:::{table} Composition of Base Cytosol. 
+Base Cytosol is assembled from four components — a protein mix (PMix), a small molecule mix (SMix), ribosomes, and tRNA. The tabs below give the composition of each component at its **stock** concentration, plus the **Final Reaction** composition with every component at its in-reaction concentration.
+
+:::::{tab-set}
+
+::::{tab-item} PMix
+The Protein Mix (PMix) contains all 36 PURE proteins at a total stock concentration of 15 µg/µL. Per-protein stock concentrations are shown below; see the [make-36pot](../../processes/make-36pot/main.md) and [make-1pot](../../processes/make-1pot/main.md) processes for preparation.
+
+:::{table} Composition of the Protein Mix (PMix) at stock concentration. Source: make-36pot process.
+:label: comp-pmix
+| Category | Protein | Concentration (ng/µL) |
+|----------|---------|-----------------------|
+| tRNA Synthetases | AlaRS | 1086 |
+| | ArgRS | 30 |
+| | AsnRS | 341 |
+| | AspRS | 125 |
+| | CysRS | 18 |
+| | GlnRS | 59 |
+| | GluRS | 196 |
+| | GlyRS | 149 |
+| | HisRS | 12 |
+| | IleRS | 622 |
+| | LeuRS | 63 |
+| | LysRS | 99 |
+| | MetRS | 36 |
+| | PheRS | 264 |
+| | ProRS | 155 |
+| | SerRS | 30 |
+| | ThrRS | 97 |
+| | TrpRS | 97 |
+| | TyrRS | 10 |
+| | ValRS | 28 |
+| Initiation Factors | IF1 | 155 |
+| | IF2 | 622 |
+| | IF3 | 155 |
+| Elongation Factors | EF-G | 777 |
+| | EF-Tu | 7764 |
+| | EF-Ts | 777 |
+| Release Factors | RF1 | 155 |
+| | RF2 | 155 |
+| | RF3 | 155 |
+| | RRF | 155 |
+| Metabolism | MTF | 311 |
+| | CK | 63 |
+| | AK | 46 |
+| | NDK | 16 |
+| | PPiase | 16 |
+| Transcription | T7RNAP | 155 |
+| **Total** | | **15 000** |
+:::
+::::
+
+::::{tab-item} SMix
+The Small Molecule Mix (SMix) contains the buffers, nucleotides, amino acids, stabilizers, and cofactors. Concentrations below are in the assembled SMix; see the [make-small-molecule-mix](../../processes/make-small-molecule-mix/main.md) process for preparation.
+
+:::{table} Composition of the Small Molecule Mix (SMix) at stock concentration. Source: make-small-molecule-mix process.
+:label: comp-smix
+| Category | Molecule | Concentration | Units |
+|----------|----------|---------------|-------|
+| Buffers | HEPES-KOH (pH 7.6) | 125 | mM |
+| | Potassium Glutamate | 250 | mM |
+| | Magnesium Acetate | 18.75 | mM |
+| Nucleotides | rATP | 5 | mM |
+| | rGTP | 5 | mM |
+| | rCTP | 2.5 | mM |
+| | rUTP | 2.5 | mM |
+| Amino Acids | Each (Ala–Val) | 0.75 | mM |
+| Stabilizers | Spermidine | 5 | mM |
+| | TCEP | 2.5 | mM |
+| Cofactors | Creatine Phosphate | 50 | mM |
+| | Folinic Acid | 0.05 | mM |
+:::
+::::
+
+::::{tab-item} Ribosomes
+:::{table} Ribosome stock concentration. Source: make-ribosomes process.
+:label: comp-ribosomes
+| Component | Stock Concentration | Reaction Concentration |
+|-----------|---------------------|------------------------|
+| Ribosomes | 10 µM (5.55×) | 1.8 µM |
+:::
+::::
+
+::::{tab-item} tRNA
+:::{table} tRNA stock concentration. Source: make-trna process.
+:label: comp-trna
+| Component | Stock Concentration | Reaction Concentration |
+|-----------|---------------------|------------------------|
+| tRNA | 35 µg/µL (10×) | 3.5 µg/µL |
+:::
+::::
+
+::::{tab-item} Final Reaction
+:::{table} Composition of Base Cytosol at reaction concentration.
 :label: comp-base-cytosol
 | Category | Molecule | Concentration | Units |
 |----------|----------|----------------------|-------|
 | Buffers | HEPES-KOH | 50 | mM |
 | | Potassium Glutamate | 100 | mM |
-| | Magnesium Acetate | 8 | mM |
+| | Magnesium Acetate | 7.5 | mM |
 | Nucleotides | rATP | 2 | mM |
 | | rGTP | 2 | mM |
 | | rCTP | 1 | mM |
@@ -65,46 +148,48 @@ Plasmid designs are included in the documentation of the [DNA Distribution](../.
 | | TCEP-HCl | 1 | mM |
 | Cofactors | Creatine Phosphate | 20 | mM |
 | | Folinic Acid | 0.02 | mM |
-| Ribonucleics | tRNA | 3.5 | μg/mL |
-| | Ribosomes | 1.8 | μM |
-| tRNA Synthetases | AlaRS | 139 | ng/μL |
-| | ArgRS | 130.3 | ng/μL |
-| | AsnRS | 3.6 | ng/μL |
-| | AspRS | 40.9 | ng/μL |
-| | CysRS | 2.2 | ng/μL |
-| | GlnRS | 7.0 | ng/μL |
-| | GluRS | 23.5 | ng/μL |
-| | GlyRS | 17.9 | ng/μL |
-| | HisRS | 1.5 | ng/μL |
-| | IleRS | 74.6 | ng/μL |
-| | LeuRS | 7.5 | ng/μL |
-| | LysRS | 11.9 | ng/μL |
-| | MetRS | 4.4 | ng/μL |
-| | PheRS | 31.7 | ng/μL |
-| | ProRS | 18.7 | ng/μL |
-| | SerRS | 3.6 | ng/μL |
-| | ThrRS | 11.6 | ng/μL |
-| | TrpRS | 11.6 | ng/μL |
-| | TyrRS | 1.2 | ng/μL |
-| | ValRS | 3.4 | ng/μL |
-| Initiation Factors | IF1 | 18.7 | ng/μL |
-| | IF2 | 74.6 | ng/μL |
-| | IF3 | 18.7 | ng/μL |
-| Elongation Factors | EF-G | 93.3 | ng/μL |
-| | EF-Tu | 932 | ng/μL |
-| | EF-Ts | 93.3 | ng/μL |
-| Release Factors | RF1 | 18.7 | ng/μL |
-| | RF2 | 18.7 | ng/μL |
-| | RF3 | 18.7 | ng/μL |
-| | RRF | 18.7 | ng/μL |
-| Metabolism | MTF | 37.3 | ng/μL |
-| | CK | 7.5 | ng/μL |
-| | AK | 5.6 | ng/μL |
-| | NDK | 1.9 | ng/μL |
-| | PPiase | 1.9 | ng/μL |
-| Transcription | T7RNAP | 18.7 | ng/μL |
-
+| Ribonucleics | tRNA | 3.5 | µg/µL |
+| | Ribosomes | 1.8 | µM |
+| tRNA Synthetases | AlaRS | 130.3 | ng/µL |
+| | ArgRS | 3.6 | ng/µL |
+| | AsnRS | 40.9 | ng/µL |
+| | AspRS | 15.0 | ng/µL |
+| | CysRS | 2.2 | ng/µL |
+| | GlnRS | 7.0 | ng/µL |
+| | GluRS | 23.5 | ng/µL |
+| | GlyRS | 17.9 | ng/µL |
+| | HisRS | 1.5 | ng/µL |
+| | IleRS | 74.6 | ng/µL |
+| | LeuRS | 7.5 | ng/µL |
+| | LysRS | 11.9 | ng/µL |
+| | MetRS | 4.4 | ng/µL |
+| | PheRS | 31.7 | ng/µL |
+| | ProRS | 18.7 | ng/µL |
+| | SerRS | 3.6 | ng/µL |
+| | ThrRS | 11.6 | ng/µL |
+| | TrpRS | 11.6 | ng/µL |
+| | TyrRS | 1.2 | ng/µL |
+| | ValRS | 3.4 | ng/µL |
+| Initiation Factors | IF1 | 18.7 | ng/µL |
+| | IF2 | 74.6 | ng/µL |
+| | IF3 | 18.7 | ng/µL |
+| Elongation Factors | EF-G | 93.3 | ng/µL |
+| | EF-Tu | 931.7 | ng/µL |
+| | EF-Ts | 93.3 | ng/µL |
+| Release Factors | RF1 | 18.7 | ng/µL |
+| | RF2 | 18.7 | ng/µL |
+| | RF3 | 18.7 | ng/µL |
+| | RRF | 18.7 | ng/µL |
+| Metabolism | MTF | 37.3 | ng/µL |
+| | CK | 7.5 | ng/µL |
+| | AK | 5.6 | ng/µL |
+| | NDK | 1.9 | ng/µL |
+| | PPiase | 1.9 | ng/µL |
+| Transcription | T7RNAP | 18.7 | ng/µL |
 :::
+::::
+
+:::::
 
 ## Expected Behavior
 

--- a/docs/processes/make-36pot/main.md
+++ b/docs/processes/make-36pot/main.md
@@ -1,5 +1,5 @@
 ---
-title: Make Protein Mix (36-pot)
+title: Make Protein Mix
 ---
 
 # Overview


### PR DESCRIPTION
Closes #130.

## What

Reorganizes the single long reaction table on the [Base Cytosol spec](docs/modules/base-cytosol/spec.md) into a five-tab tab-set so individual sub-components are easy to find and reference:

- **PMix** — 36 PURE proteins at stock concentration (ng/µL), total 15 mg/mL
- **SMix** — buffers, nucleotides, amino acids, stabilizers, cofactors at SMix stock concentration
- **Ribosomes** — 10 µM (5.55×) stock
- **tRNA** — 35 µg/µL (10×) stock
- **Final Reaction** — all components at in-reaction concentration

Also per the issue: the schematic is pulled out of the old Schematic/Designs tab-set as a standalone figure, the Designs tab is removed, and an inline link now points at the DNA repo's [`PURE/expression`](https://github.com/nucleus-eng/DNA/tree/main/PURE/expression) vectors.

All component tabs are sourced from their authoritative prep processes (PMix → make-36pot, SMix → make-small-molecule-mix, Ribosomes → make-ribosomes, tRNA → make-trna).

## Data corrections (heads-up for review)

Rebuilding the Final Reaction tab from the source processes corrected several latent errors in the prior table:

| Component | Was | Now | Source |
|---|---|---|---|
| AlaRS | 139 | 130.3 | make-36pot |
| ArgRS | 130.3 | 3.6 | make-36pot |
| AsnRS | 3.6 | 40.9 | make-36pot |
| AspRS | 40.9 | 15.0 | make-36pot |
| EF-Tu | 932 | 931.7 | make-36pot |
| Magnesium Acetate | 8 mM | 7.5 mM | make-small-molecule-mix |
| tRNA | 3.5 µg/mL | 3.5 µg/µL | make-trna (was off by 1000×) |

The first four are an off-by-one shift in the synthetase block of the old table.

## Note

`make-1pot` lists PMix reaction concentration as 2.4 mg/mL vs `make-36pot`'s 1.8 mg/mL. This is intentional (different prep methods use different final loadings), so it was left as-is; the spec reflects the standard 1.8 mg/mL composition.

## QA

- `check-dropdowns.py`, Vale (0 errors), codespell, `check-links.py` (8/8 incl. new DNA link) — all clean
- `myst build --html` builds the page with no errors/warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)