### PR TITLE
feat: add OnePot PURE Workshop guide page

### DIFF
--- a/guides/main.md
+++ b/guides/main.md
@@ -24,6 +24,7 @@ Guides provide tutorials, how-tos, and reference documentation to help you get t
 ## Workshops
 
 - [Liposome Workshop](liposome-workshop/main.md) — two-day hands-on curriculum for building synthetic cells using the PURE Cell platform
+- [OnePot PURE Workshop](onepot-pure-workshop/main.md) — five-day hands-on curriculum for assembling OnePot PURE cytosol from scratch
 
 ## Contributing
 

--- a/guides/onepot-pure-workshop/main.md
+++ b/guides/onepot-pure-workshop/main.md
@@ -1,0 +1,23 @@
+---
+title: "OnePot PURE Workshop"
+subtitle: "Guide"
+---
+
+# Overview
+
+The Nucleus OnePot PURE Workshop is a five-day hands-on curriculum for introducing new cell builders to OnePot PURE assembly. Participants work through the full workflow from protein expression through cytosol assembly and characterization.
+
+The workshop materials are designed to be self-contained and reusable — suitable for university courses, lab onboarding, or community science events. If you are interested in running a workshop or have questions about the materials, reach out to [build@bnext.bio](mailto:build@bnext.bio).
+
+# Materials
+
+The following materials are available for download. All materials are hosted on Google Drive.
+
+| Material | Description | Download |
+| -------- | ----------- | -------- |
+| Protocols | OnePot PURE bench protocols (v1.0) | [link](https://drive.google.com/file/d/1WzAI7QQy_LT1NzLR_YR-0SfEDorlH6Ak/view?usp=drive_link) |
+| Protein Buffers | Protein buffer formulations (v1.0) | [link](https://drive.google.com/file/d/1PogtQ7rLMcBzknL8wT-9Wkk3qPuwAbNv/view?usp=drive_link) |
+| Ribosome Buffers | Ribosome buffer formulations (v1.0) | [link](https://drive.google.com/file/d/1vSfySIT8QorPMLEzQhXrULzAL1wv28-n/view?usp=drive_link) |
+| DNA Distribution | Workshop genetic constructs | [GitHub](https://github.com/bnext-bio/nucleus/tree/main/dna-distribution/nucleus-pure-workshop-01) |
+| Schedule | Five-day workshop agenda | [link](https://drive.google.com/file/d/1AT9Bft0udC4CHKze8Qcp2ugeBCbBXRGN/view?usp=drive_link) |
+| Bill of Materials | Consumables and reagents list for the full workshop | [link](https://drive.google.com/file/d/1fonZ3BunwNFRBsgZqN3qKoqv4dXw0AGd/view?usp=drive_link) |

--- a/myst.yml
+++ b/myst.yml
@@ -111,6 +111,8 @@ project:
           hidden: true
         - file: ./guides/liposome-workshop/main.md
           hidden: true
+        - file: ./guides/onepot-pure-workshop/main.md
+          hidden: true
     - title: About
       children:
         # - file: ./about/open-science.md


### PR DESCRIPTION
## Summary

- Adds `guides/onepot-pure-workshop/main.md` — a five-day workshop guide page modelled on the existing Liposome Workshop page
- Materials table covers protocols, protein buffers, ribosome buffers, DNA distribution, schedule, and BOM — all with Google Drive / GitHub download links
- Added to `myst.yml` TOC and `guides/main.md` Workshops section

## Test plan

- [ ] Confirm page renders at `/guides/onepot-pure-workshop/`
- [ ] Confirm all download links resolve
- [ ] Confirm page appears under Workshops in the Guides index

🤖 Generated with [Claude Code](https://claude.com/claude-code)