### PR TITLE
feat: update license page with three-license model and extract OpenMTA

### DIFF
--- a/about/license.md
+++ b/about/license.md
@@ -2,59 +2,10 @@
 title: License
 --- 
 
-The Nucleus Distribution is licensed under the [CERN-OHL-P-2.0](https://github.com/nucleus-eng/nucleus-docs/blob/main/LICENSE.md). Physical materials described in the Documentation is made available upon request to build@bnext.bio under the [OpenMTA](https://www.openplant.org/openmta).
+Nucleus content is made available under different licenses depending on its type — all permissive and designed to be compatible with one another, so material can move freely between documentation, designs, and code without licensing conflicts:
 
+[CERN-OHL-P-2.0](https://spdx.org/licenses/CERN-OHL-P-2.0.html) — DNA, module, and cell designs, protocols, formulations, sequence maps, and characterization data (the Nucleus Distribution).
+[CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/deed.en) — narrative documentation, figures, and datasets, including DevNotes.
+[MIT](https://opensource.org/license/mit) — software and the Nucleus CDK.
 
-:::{admonition} OpenMTA
-:class: simple, dropdown
-:icon: false
-
-This Open Material Transfer Agreement (the “OpenMTA”) and the attached Implementing Letter (the “Implementing Letter” and, together with the OpenMTA, the “Agreement”) is entered into between the Provider and the Recipient (or the “Parties”, as further identified in the Implementing Letter) and governs the exchange and use of certain materials specified in this Agreement between the Parties. The provisions of this OpenMTA shall be given precedence in interpretation in the event of any conflict between this OpenMTA and the Implementing Letter.
-
-I. DEFINITIONS:
-
-1. Provider: Organization providing the Original Material. The name and address of this party will be specified in an implementing letter.
-
-2. Provider Scientist: The name and address of this party will be specified in an implementing letter.
-
-3. Recipient: Organization receiving the Original Material. The name and address of this party will be specified in an implementing letter.
-
-4. Recipient Scientist: The name and address of this party will be specified in an implementing letter.
-
-5. Original Material: The description of the Material being transferred will be specified in an implementing letter.
-
-6. Material: Original Material, Progeny, and Unmodified Derivatives. The Material shall not include: (a) Modifications, or (b) other substances created by the Recipient through the use of the Material, which are not Modifications, Progeny, or Unmodified Derivatives.
-
-7. Progeny: Unmodified descendant from the Material, such as virus from virus, cell from cell, or organism from organism.
-
-8. Unmodified Derivatives: Substances created by the Recipient which constitute an unmodified functional subunit or product expressed by the Original Material. Some examples include: subclones of unmodified cell lines, purified or fractionated subsets of the Original Material, proteins expressed by DNA/RNA supplied by Provider, or monoclonal antibodies secreted by a hybridoma cell line.
-
-9. Modifications: Substances created by the Recipient which contain/incorporate the Material.
-
-10. Commercial Purposes: The sale, lease, license, or other transfer of the Materials or Modifications to a for-profit organization. Commercial Purposes shall also include uses of the Material or Modifications by any organization, including Recipient, to perform contract research, to produce or manufacture products for general sale, or to conduct research activities that result in any sale, lease, license, or transfer of the Material or Modifications to a for-profit organization.
-
-II. TERMS AND CONDITIONS OF THIS AGREEMENT
-
-The Provider is making the Material available as a service to the research community. The Recipient may use the Material for any lawful purpose, including Commercial Purposes, in accordance with the following terms and conditions:
-
-1. Use: The Recipient shall use, store, and dispose of the Material and any Modifications in accordance with good laboratory practice and shall ensure compliance with all applicable laws, rules, and regulations, including laws, rules, and regulations governing export control and safety.
-
-2. Attribution: The Recipient agrees to provide appropriate acknowledgement of the source of the Material as requested by the Provider. Any request for attribution will be specified in an implementing letter.
-
-3. Distribution: The Recipient may distribute the Material and substances created by the Recipient through use of the Material, including Progeny, Unmodified Derivatives, and Modifications, without requesting consent from the Provider. Recipient agrees to notify the Provider of any distributions of the Material to third parties as requested by the Provider. Any request for notification will be specified in an implementing letter.
-
-4. Fees: The Material is provided at no cost, or with an optional transmittal fee solely to reimburse the Provider for its preparation and distribution costs. If a fee is requested, the amount will be specified in an implementing letter.
-
-5. No Implied License: Except for the rights expressly granted herein, the Recipient agrees that no other rights or licenses, whether express or implied, are granted to the Recipient under any patent, patent application, or other proprietary right of the Provider. As between the parties, each retains all right, title, and interest in works and inventions made by its personnel, and nothing herein shall be construed to transfer ownership of any invention, patent, patent application, or other proprietary right.
-
-6. Liability: Except to the extent prohibited by law, the Recipient assumes all liability for damages that may arise from the use, storage or disposal of the Material. The Provider will not be liable to the Recipient for any loss, claim or demand made by the Recipient, or made against the Recipient by any other party, due to or arising from the use of the Material by the Recipient, except to the extent permitted by law when caused by the gross negligence or willful misconduct of the Provider.
-
-7. No Warranties: Any Material delivered pursuant to the Agreement is understood to be experimental in nature and may have hazardous properties. THE PROVIDER MAKES NO REPRESENTATIONS AND EXTENDS NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED. THERE ARE NO EXPRESS OR IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, OR THAT THE USE OF THE MATERIAL WILL NOT INFRINGE ANY PATENT, COPYRIGHT, TRADEMARK, OR OTHER PROPRIETARY RIGHTS.
-
-III. ADDITIONAL TERMS
-
-1. Recipient agrees to provide appropriate acknowledgement of the source of the Material in all publications.
-
-2. Recipient agrees to notify the Provider upon redistribution of the Material to third parties.
-   
-:::
+**Physical materials.** The [Nucleus plasmid collection](https://github.com/nucleus-eng/DNA) is available upon request to build@bnext.bio under the [OpenMTA](https://www.openplant.org/openmta). Onboarding onto AddGene is in progress, expected September 2026.

--- a/openmta.md
+++ b/openmta.md
@@ -1,0 +1,48 @@
+This Open Material Transfer Agreement (the “OpenMTA”) and the attached Implementing Letter (the “Implementing Letter” and, together with the OpenMTA, the “Agreement”) is entered into between the Provider and the Recipient (or the “Parties”, as further identified in the Implementing Letter) and governs the exchange and use of certain materials specified in this Agreement between the Parties. The provisions of this OpenMTA shall be given precedence in interpretation in the event of any conflict between this OpenMTA and the Implementing Letter.
+
+I. DEFINITIONS:
+
+1. Provider: Organization providing the Original Material. The name and address of this party will be specified in an implementing letter.
+
+2. Provider Scientist: The name and address of this party will be specified in an implementing letter.
+
+3. Recipient: Organization receiving the Original Material. The name and address of this party will be specified in an implementing letter.
+
+4. Recipient Scientist: The name and address of this party will be specified in an implementing letter.
+
+5. Original Material: The description of the Material being transferred will be specified in an implementing letter.
+
+6. Material: Original Material, Progeny, and Unmodified Derivatives. The Material shall not include: (a) Modifications, or (b) other substances created by the Recipient through the use of the Material, which are not Modifications, Progeny, or Unmodified Derivatives.
+
+7. Progeny: Unmodified descendant from the Material, such as virus from virus, cell from cell, or organism from organism.
+
+8. Unmodified Derivatives: Substances created by the Recipient which constitute an unmodified functional subunit or product expressed by the Original Material. Some examples include: subclones of unmodified cell lines, purified or fractionated subsets of the Original Material, proteins expressed by DNA/RNA supplied by Provider, or monoclonal antibodies secreted by a hybridoma cell line.
+
+9. Modifications: Substances created by the Recipient which contain/incorporate the Material.
+
+10. Commercial Purposes: The sale, lease, license, or other transfer of the Materials or Modifications to a for-profit organization. Commercial Purposes shall also include uses of the Material or Modifications by any organization, including Recipient, to perform contract research, to produce or manufacture products for general sale, or to conduct research activities that result in any sale, lease, license, or transfer of the Material or Modifications to a for-profit organization.
+
+II. TERMS AND CONDITIONS OF THIS AGREEMENT
+
+The Provider is making the Material available as a service to the research community. The Recipient may use the Material for any lawful purpose, including Commercial Purposes, in accordance with the following terms and conditions:
+
+1. Use: The Recipient shall use, store, and dispose of the Material and any Modifications in accordance with good laboratory practice and shall ensure compliance with all applicable laws, rules, and regulations, including laws, rules, and regulations governing export control and safety.
+
+2. Attribution: The Recipient agrees to provide appropriate acknowledgement of the source of the Material as requested by the Provider. Any request for attribution will be specified in an implementing letter.
+
+3. Distribution: The Recipient may distribute the Material and substances created by the Recipient through use of the Material, including Progeny, Unmodified Derivatives, and Modifications, without requesting consent from the Provider. Recipient agrees to notify the Provider of any distributions of the Material to third parties as requested by the Provider. Any request for notification will be specified in an implementing letter.
+
+4. Fees: The Material is provided at no cost, or with an optional transmittal fee solely to reimburse the Provider for its preparation and distribution costs. If a fee is requested, the amount will be specified in an implementing letter.
+
+5. No Implied License: Except for the rights expressly granted herein, the Recipient agrees that no other rights or licenses, whether express or implied, are granted to the Recipient under any patent, patent application, or other proprietary right of the Provider. As between the parties, each retains all right, title, and interest in works and inventions made by its personnel, and nothing herein shall be construed to transfer ownership of any invention, patent, patent application, or other proprietary right.
+
+6. Liability: Except to the extent prohibited by law, the Recipient assumes all liability for damages that may arise from the use, storage or disposal of the Material. The Provider will not be liable to the Recipient for any loss, claim or demand made by the Recipient, or made against the Recipient by any other party, due to or arising from the use of the Material by the Recipient, except to the extent permitted by law when caused by the gross negligence or willful misconduct of the Provider.
+
+7. No Warranties: Any Material delivered pursuant to the Agreement is understood to be experimental in nature and may have hazardous properties. THE PROVIDER MAKES NO REPRESENTATIONS AND EXTENDS NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED. THERE ARE NO EXPRESS OR IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, OR THAT THE USE OF THE MATERIAL WILL NOT INFRINGE ANY PATENT, COPYRIGHT, TRADEMARK, OR OTHER PROPRIETARY RIGHTS.
+
+III. ADDITIONAL TERMS
+
+1. Recipient agrees to provide appropriate acknowledgement of the source of the Material in all publications.
+
+2. Recipient agrees to notify the Provider upon redistribution of the Material to third parties.
+   


### PR DESCRIPTION
- Replace single-sentence license page with a clear breakdown of the three applicable licenses: CERN-OHL-P-2.0 (designs/protocols), CC-BY-4.0 (documentation/DevNotes), MIT (software/CDK)
- Add physical materials section with OpenMTA link and AddGene onboarding timeline
- Extract full OpenMTA legal text verbatim into openmta.md at repo root
- Remove inline OpenMTA dropdown (full text now in dedicated file)