### PR TITLE
feat: add contributors page

### DIFF
--- a/about/contributors.md
+++ b/about/contributors.md
@@ -1,0 +1,43 @@
+---
+title: Contributors
+---
+
+The following have contributed to the content on this site:
+
+- Adriana Hudyma
+- Ahmed Sihorwala
+- Anton Jackson-Smith
+- Anton Molina
+- Charlie Newell
+- Drew Endy
+- Elizabeth Strychalski
+- Evan Kalb
+- Hanqiao Zhang
+- Jake Stillson
+- Jay Bhasin
+- Jefferson Smith
+- Jenny Molloy
+- Jon Calles
+- Kate Adamala
+- Leon Elcock
+- Matas Deveikis
+- Michael Booth
+- Miki Yun
+- Parsa Parivizian
+- Paul Freemont
+- Richard Murray
+- Riku Nagai
+- Severine Cazaux
+- Sharon Newman
+- Surendra Yadav
+- Tyler Goshia
+- Viktoriia Belousova
+- Yan Zhang
+- Yemo Ku
+- Yen-Yu Hsu
+- Yoshihiro Shimizu
+- Zoila Jurado
+
+Many others have made their work available as Developer Notes that have not yet been integrated into the Documentation. Browse published [DevNotes](https://devnotes.nucleus.engineering).
+
+If you feel your name should be here, please reach out to build@bnext.bio.

--- a/myst.yml
+++ b/myst.yml
@@ -117,6 +117,7 @@ project:
       children:
         # - file: ./about/open-science.md
         - file: ./about/license.md
+        - file: ./about/contributors.md
         - file: ./about/faqs.md
         - file: ./about/release-notes.md
           children:


### PR DESCRIPTION
## Summary

- Adds `about/contributors.md` with an alphabetical list of 33 contributors
- Adds the page to the About section of the TOC in `myst.yml`
- Removes the empty `about/contributions.md` stub

Closes #131

## Test plan

- [ ] Contributors page renders correctly at `/about/contributors`
- [ ] Page appears in the About section of the sidebar
- [ ] All names display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)