### PR TITLE
fix: resolve myst build warnings and errors

### DIFF
--- a/docs/modules/membrane-popc-chol/spec.md
+++ b/docs/modules/membrane-popc-chol/spec.md
@@ -27,7 +27,7 @@ Schematic of a POPC/Chol liposome.
 ## Reference Composition
 
 :::{table}
-:label: comp-membrane
+:label: comp-membrane-spec
 | Component | Target Percentage (%) | Molecular Weight (g/mol) | Stock concentration (mg/mL) | Volume to add (uL) |
 | --- | --- | --- | --- | --- |
 | POPC | 70 | 760.076 | 25 | 162.17 |

--- a/docs/modules/reporter-degfp/spec.md
+++ b/docs/modules/reporter-degfp/spec.md
@@ -97,7 +97,6 @@ Final protein yields of the reactions measured at steady state. Data from [DevNo
 ::::{tab-item} Cytosol
 
 :::{table}
-:::
 | Component | Input concentration | Unit | Final concentration | Unit | Volume for one reaction (µL) |
 | --- | --- | --- | --- | --- | --- |
 | SMix | 3.33 | × | 1 | × | 12 |
@@ -110,7 +109,7 @@ Final protein yields of the reactions measured at steady state. Data from [DevNo
 | RNase Inhibitor | 40000 | U/mL | 2000 | U/mL | 2 |
 | Water |  |  |  |  | 6.12 |
 | Total volume (µL) |  |  |  |  | 40 |
-::::
+:::
 
 ::::{tab-item} Membrane
 :::{table}

--- a/docs/processes/make-1pot/main.md
+++ b/docs/processes/make-1pot/main.md
@@ -190,7 +190,6 @@ This protocol processes two 500 mL OnePot PURE cultures, yielding ~600 µL purif
 :::{table} Protein Purification Buffers
 :label: protein-buffers
 :align: center
-:width: 75%
 
 | Buffer Type | Buffer A (mL) | Buffer B (mL) | Total (mL) | 0.5 M TCEP (µL) |
 | --- | --- | --- | --- | --- |

--- a/docs/processes/make-trna/main.md
+++ b/docs/processes/make-trna/main.md
@@ -46,7 +46,7 @@ Please read this section carefully. It contains important notes, resources, and 
 :icon: false
 
 :::{table} 
-:label: tbl:composition-table
+:label: tbl:composition-table-trna
 :align: center
 
 | **Component** | **Stock Concentration** | **Reaction Concentration** |

--- a/guides/developer-note-syntax.md
+++ b/guides/developer-note-syntax.md
@@ -80,7 +80,7 @@ Illustration of the PPK2 based energy regeneration the PURE system.
 :class: dropdown
 
 :::{figure} https://github.com/bnext-bio/nucleus-developer-notes/blob/main/dev-notes/04_ppk/figures/PPK-illustration.png
-:label: fig:my-fig-1
+:label: fig:my-fig-2
 :align: left
 
 Illustration of the PPK2 based energy regeneration the PURE system. 
@@ -95,9 +95,6 @@ Illustration of the PPK2 based energy regeneration the PURE system.
 Tables follow the same basic patterns as figures:
 
 :::{table}
-:option-1: parameter-1
-:option-2: parameter-2
-:option-3: parameter-3
 
 | Header 1 | Header 2 | Header 3 |
 | --- | --- | --- |

--- a/guides/developer-notes/developer-notes.md
+++ b/guides/developer-notes/developer-notes.md
@@ -11,9 +11,9 @@ This guide will introduce you to Developer Notes (DevNotes) as a way to quickly 
 
 Most of the DevNote tools that appear in the Launcher require setting up API access to [Curvenote](https://editor.curvenote.com/) to work as expected. API access can be set up by following these steps:
 
-- [ ] Navigate to the Curvenote [website](https://editor.curvenote.com/) and [create an account](curvenote-login).
+- [ ] Navigate to the Curvenote [website](https://editor.curvenote.com/) and [create an account](#curvenote-login).
 - [ ] Create a new blank project and click ‘NEXT’
-- [ ]  Go to [personal settings](curvenote-settings).
+- [ ]  Go to [personal settings](#curvenote-settings).
 - [ ]  Select ‘API Access’ and click ‘Generate New Token’.
   - [ ]  Give the token a useful description and select Expiry for the maximum time allowed.
 - [ ]  From Nucleus Hub, open a terminal window from the Launcher and run the command `curvenote token set [my-token]`
@@ -66,8 +66,8 @@ DevNotes are written using [MyST Markdown](https://mystmd.org/), a flavor of Mar
   - [ ] Open the file `main.md` in your directory.
   - [ ] Open a new Launcher window by clicking the "+" at the top of the screen.
   - [ ] Click the button "Preview" in the "Developer Notes" toolbar of the Launcher window. Note: you must be in `devnotes/my-project` directory.
-  - [ ] You may see an [error message](hub-error). That’s ok.
-  - [ ] Create a [split screen](hub-splitscreen) by dragging the "Preview" tab to the right corner of the screen.
+  - [ ] You may see an [error message](#hub-error). That’s ok.
+  - [ ] Create a [split screen](#hub-splitscreen) by dragging the "Preview" tab to the right corner of the screen.
   - [ ] Make an edit, say to the level 1 heading, e.g. `#Background - edited`. The preview window should automatically refresh and you should now be able to preview any updates to your DevNote in realtime.
 
 **Notes**

--- a/guides/devnote-tutorial.md
+++ b/guides/devnote-tutorial.md
@@ -31,11 +31,11 @@ If you do not have these things please see the [Tutorial: getting started with N
   - [ ] Exit the terminal and return to the Launcher Window
 
 - [ ] Preview your DevNote.
-  - [ ] In your file directory, navigate to the directory `/devnotes/template` it should appear like [this]().
+  - [ ] In your file directory, navigate to the directory `/devnotes/template`.
   - [ ] While you're in the `devnotes/template` directory, click the button "Preview" in the "Developer Notes" toolbar of the Launcher window.
-  - [ ] You will likely see an [error message](fig:error). That's ok.
+  - [ ] You will likely see an [error message](#fig:error). That's ok.
   - [ ] Open the file `main.md` in your directory
-  - [ ] Create a [split screen](fig:splitscreen) by dragging the "Preview" tab to the right corner of the screen.
+  - [ ] Create a [split screen](#fig:splitscreen) by dragging the "Preview" tab to the right corner of the screen.
   - [ ] Make an edit, say to the level 1 heading, e.g. `#Background - edited`. The preview window should automatically refresh and you should now be able to preview any updates to your DevNote in realtime.
 
 :::::{tab-set}

--- a/guides/nucleus-hub/nucleus-hub.md
+++ b/guides/nucleus-hub/nucleus-hub.md
@@ -17,27 +17,27 @@ Currently, access to Nucleus Hub is available by request. If you are a Nucleus C
 
 # Orientation
 
-Upon entering Nucleus Hub you should see the the Nucleus Hub [landing page](hub-landing). This section will describe a few key interfaces that are frequently used in common workflows. Since Nucleus Hub builds on JupyterLab, an exhaustive description of the interface can be found in the [JupyterLab Docs](https://jupyterlab.readthedocs.io/en/stable/user/interface.html#main-area).
+Upon entering Nucleus Hub you should see the the Nucleus Hub [landing page](#hub-landing). This section will describe a few key interfaces that are frequently used in common workflows. Since Nucleus Hub builds on JupyterLab, an exhaustive description of the interface can be found in the [JupyterLab Docs](https://jupyterlab.readthedocs.io/en/stable/user/interface.html#main-area).
 
 :::::{tab-set}
 
 ::::{tab-item} Landing Page
 :::{figure} hub-landing.png
-:label: hub-landing
+:name: hub-landing
 Nucleus Hub landing page. 
 :::
 ::::
 
 ::::{tab-item} File Browser
 :::{figure} hub-file-browser.png
-:label: hub-file-browser
+:name: hub-file-browser
 The file browser allows you to navigate your home directory to which notebooks, scripts, datasets, and other files can be saved.
 :::
 ::::
 
 ::::{tab-item} Launcher
 :::{figure} hub-launcher.png
-:label: hub-launcher
+:name: hub-launcher
 The Launcher allows you quickly start a new activity such as creating a new template notebook or creating a new Developer Note.
 :::
 ::::
@@ -46,7 +46,7 @@ The Launcher allows you quickly start a new activity such as creating a new temp
 
 ## File Browser
 
-Nucleus Hub allows you with a home directory that allows you to save files. To learn more about your home directory and your filesystem, please refer to this documentation [page](https://2i2c.org/community-showcase/user/topics/data/filesystem.html) from 2i2c. The [file browser](hub-file-browser) is the main interface for managing notebooks, scripts, datasets, and other file types. A few directories exist by default:
+Nucleus Hub allows you with a home directory that allows you to save files. To learn more about your home directory and your filesystem, please refer to this documentation [page](https://2i2c.org/community-showcase/user/topics/data/filesystem.html) from 2i2c. The [file browser](#hub-file-browser) is the main interface for managing notebooks, scripts, datasets, and other file types. A few directories exist by default:
 
 :::{table}
 
@@ -63,7 +63,7 @@ Nucleus Hub allows you with a home directory that allows you to save files. To l
 
 ## Launcher
 
-Common Nucleus Hub workflows can be initiated from the [Launcher](hub-launcher). The button on the Launcher window are organized into the following categories:
+Common Nucleus Hub workflows can be initiated from the [Launcher](#hub-launcher). The button on the Launcher window are organized into the following categories:
 
 :::{table}
 
@@ -100,10 +100,10 @@ If you are a newcomer to Python and Jupyter the following links may be helpful:
 
 # Uploading data into the hub
 
-Small datasets (>25 MB) can be uploaded [directly](hub-upload) into the hub or by drag-and-drop directly into the file browser (e.g. typical plate reader datasets or individual PNGs). We recommend organizing your data by experiment in a directory in your home directory. For example: `/home/work/2026-04-02_my-experiment`.
+Small datasets (>25 MB) can be uploaded [directly](#hub-upload) into the hub or by drag-and-drop directly into the file browser (e.g. typical plate reader datasets or individual PNGs). We recommend organizing your data by experiment in a directory in your home directory. For example: `/home/work/2026-04-02_my-experiment`.
 
 :::{figure} hub-upload-data.png
-:label: hub-upload
+:name: hub-upload
 Data can directly uploaded into the hub.
 :::
 

--- a/guides/platemap_tutorial.md
+++ b/guides/platemap_tutorial.md
@@ -19,10 +19,9 @@ A *platemap* is a file that records what you put on your plate and where.
 
 ## Step 1 - make a blank plate map
 
-Create a blank plate map in the spreadsheet editor of your choice. An example of a basic plate map containing all the required fields is shown [below](fig-platemap_example_minimal). Plate maps **must** have the following columns, so that for each well you indicate:
+Create a blank plate map in the spreadsheet editor of your choice. An example of a basic plate map containing all the required fields is shown [below](#fig-platemap_example_minimal). Plate maps **must** have the following columns, so that for each well you indicate:
 
 ::::{card} Column Requirements
-:header: 
 
 - `Date` — Experiment date
 - `Experiment` — a name that gives a brief description of the overall experiment for that well
@@ -82,7 +81,7 @@ For each well on your plate, add a row to the plate map, filling in as much meta
 
 ### Including additional data
 
-If you have any additional information you have about what you are plating, consider including it as [additional columns](fig-platemap_example_rec). For example, it is often useful to describe the amount of specific materials that are used in your reaction. We often refer to a specific material that might live in your refrigerator as an artifact and give it a unique ID to keep track of it. For example:   
+If you have any additional information you have about what you are plating, consider including it as [additional columns](#fig-platemap_example_rec). For example, it is often useful to describe the amount of specific materials that are used in your reaction. We often refer to a specific material that might live in your refrigerator as an artifact and give it a unique ID to keep track of it. For example:   
 
 - `<artifact> ID` for material that can be cross-referenced against a specific reagent in your inventory; replace `<artifact>` with the identity of that material (e.g., `fluorescein stock 2`)
 - `[<artifact>] (<units>)` — indicate concentration (in well, not stock!) with square brackets

--- a/guides/platemap_tutorial.md
+++ b/guides/platemap_tutorial.md
@@ -37,7 +37,6 @@ Create a blank plate map in the spreadsheet editor of your choice. An example of
     :::
 
 - `Rxn Volume (uL)` — total volume of liquid in well
-- 
 ::::
 
 :::::{tab-set}

--- a/myst.yml
+++ b/myst.yml
@@ -91,8 +91,6 @@ project:
           hidden: true
         - file: ./guides/tutorials.md
           hidden: true
-        - file: ./guides/nucleus-hub/nucleus-hub.md
-          hidden: true
         - file: ./guides/contribution-guide.md
           hidden: true
         - file: ./guides/materials-reference.md

--- a/start/getting-started.md
+++ b/start/getting-started.md
@@ -25,7 +25,7 @@ The seventh release of the Nucleus Distribution (v0.5.0) is now available. Check
 
 ## Get started
 
-If you're new to Nucleus, checkout [From Zero to DevNote](). That guide will walk you through the documentation.
+If you're new to Nucleus, checkout [From Zero to DevNote](./first-guide.md). That guide will walk you through the documentation.
 
 ## Get in touch
 


### PR DESCRIPTION
## Summary

- Fixes all `⛔️` errors and `⚠️` warnings surfaced by `myst build --html`, leaving only the known `hide-toc` config noise and the cx43 xref false positive (both documented in #176)
- Cleans up legacy MyST link syntax, duplicate TOC entries, duplicate labels, and invalid directive options across guides and docs pages

## Changes

**Broken links / malformed syntax (⛔️ errors)**
- `start/getting-started.md` — fix empty link URL ("From Zero to DevNote")
- `docs/modules/reporter-degfp/spec.md` — fix malformed table fence (missing body)

**Legacy link syntax (⚠️ warnings)**
- Add `#` prefix to 12 internal anchor links across `nucleus-hub.md`, `developer-notes.md`, `devnote-tutorial.md`, `platemap_tutorial.md` — MyST now requires `[text](#anchor)` not `[text](anchor)`

**Duplicate identifiers (⚠️ warnings)**
- `myst.yml` — remove duplicate hidden TOC entry for `nucleus-hub.md` (was being built twice, causing all its figure labels to register twice)
- `developer-note-syntax.md` — rename second `fig:my-fig-1` → `fig:my-fig-2`
- `membrane-popc-chol/spec.md` — rename `comp-membrane` → `comp-membrane-spec` (collided with same label in `assemble-base-cell/main.md`)
- `make-trna/main.md` — rename `tbl:composition-table` → `tbl:composition-table-trna` (collided with same label in `make-small-molecule-mix/main.md`)

**Invalid directive options (⚠️ warnings)**
- `make-1pot/main.md` — remove unsupported `:width:` from `:::{table}`
- `developer-note-syntax.md` — remove placeholder `:option-N:` keys from rendered `:::{table}`
- `platemap_tutorial.md` — remove empty `:header:` from `::::{card}`

## Remaining known noise
- 12× `'site' extra key ignored: hide-toc` — intentional frontmatter on 12 pages; correct MyST key unknown
- `⛔️ membrane-pore-cx43/spec.md Cannot find image` — false positive from `xref:devnote-cx43#fig:scheme`; image is served remotely and renders correctly

Both documented in #176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)