### PR TITLE
fix: use absolute paths in Mermaid click directives

### DIFF
--- a/docs/processes/processes-main.md
+++ b/docs/processes/processes-main.md
@@ -27,10 +27,10 @@ flowchart TB
     style MemSpec fill:#6B7280,color:#ffffff,stroke:#4B5563
     style J fill:none,stroke:none
 
-    click BaseCytosol "../modules/base-cytosol/spec"
-    click BaseCell "./assemble-base-cell/main"
-    click ModSpec "../modules/modules-main"
-    click MemSpec "../modules/membrane-popc-chol/spec"
+    click BaseCytosol "/modules/base-cytosol/spec"
+    click BaseCell "/processes/assemble-base-cell/main"
+    click ModSpec "/modules/modules-main"
+    click MemSpec "/modules/membrane-popc-chol/spec"
 ```
 
 - [Assemble Base Cell](./assemble-base-cell/main.md)
@@ -59,13 +59,13 @@ flowchart LR
     style ModSpec fill:#6B7280,color:#ffffff,stroke:#4B5563
     style J fill:none,stroke:none
 
-    click AminoAcids "./make-amino-acid-mix/main"
-    click SMix "./make-small-molecule-mix/main"
-    click tRNA "./make-trna/main"
-    click PMix "./make-36pot/main"
-    click Ribosomes "./make-ribosomes/main"
-    click BaseCytosol "./assemble-base-cytosol/main"
-    click ModSpec "../modules/modules-main"
+    click AminoAcids "/processes/make-amino-acid-mix/main"
+    click SMix "/processes/make-small-molecule-mix/main"
+    click tRNA "/processes/make-trna/main"
+    click PMix "/processes/make-36pot/main"
+    click Ribosomes "/processes/make-ribosomes/main"
+    click BaseCytosol "/processes/assemble-base-cytosol/main"
+    click ModSpec "/modules/modules-main"
 ```
 
 - [Assemble Base Cytosol](./assemble-base-cytosol/main.md)

--- a/docs/processes/processes-main.md
+++ b/docs/processes/processes-main.md
@@ -27,10 +27,10 @@ flowchart TB
     style MemSpec fill:#6B7280,color:#ffffff,stroke:#4B5563
     style J fill:none,stroke:none
 
-    click BaseCytosol "/modules/base-cytosol/spec"
-    click BaseCell "/processes/assemble-base-cell/main"
-    click ModSpec "/modules/modules-main"
-    click MemSpec "/modules/membrane-popc-chol/spec"
+    click BaseCytosol "/docs/modules/base-cytosol/spec"
+    click BaseCell "/docs/processes/assemble-base-cell/main"
+    click ModSpec "/docs/modules/modules-main"
+    click MemSpec "/docs/modules/membrane-popc-chol/spec"
 ```
 
 - [Assemble Base Cell](./assemble-base-cell/main.md)
@@ -59,13 +59,13 @@ flowchart LR
     style ModSpec fill:#6B7280,color:#ffffff,stroke:#4B5563
     style J fill:none,stroke:none
 
-    click AminoAcids "/processes/make-amino-acid-mix/main"
-    click SMix "/processes/make-small-molecule-mix/main"
-    click tRNA "/processes/make-trna/main"
-    click PMix "/processes/make-36pot/main"
-    click Ribosomes "/processes/make-ribosomes/main"
-    click BaseCytosol "/processes/assemble-base-cytosol/main"
-    click ModSpec "/modules/modules-main"
+    click AminoAcids "/docs/processes/make-amino-acid-mix/main"
+    click SMix "/docs/processes/make-small-molecule-mix/main"
+    click tRNA "/docs/processes/make-trna/main"
+    click PMix "/docs/processes/make-36pot/main"
+    click Ribosomes "/docs/processes/make-ribosomes/main"
+    click BaseCytosol "/docs/processes/assemble-base-cytosol/main"
+    click ModSpec "/docs/modules/modules-main"
 ```
 
 - [Assemble Base Cytosol](./assemble-base-cytosol/main.md)


### PR DESCRIPTION
## Summary

- Fixes broken links in the two Mermaid flowcharts on `docs/processes/processes-main.md`
- MyST serves pages at directory-style URLs with trailing slashes, so relative paths (e.g. `./assemble-base-cell/main`, `../modules/base-cytosol/spec`) resolved one level too deep, producing 404s
- Switched all 11 `click` directives to absolute paths prefixed with `/docs/`

Closes #168

## Test plan

- [ ] Build the site and navigate to the Processes page
- [ ] Click each node in both Mermaid diagrams and confirm it lands on the correct page (no 404s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)