### PR TITLE
SpudCell spec TODO work plans

### DIFF
--- a/.claude/plans/spudcell/01-new-pages.md
+++ b/.claude/plans/spudcell/01-new-pages.md
@@ -55,7 +55,7 @@ For each page P1–P3, in order:
 
 1. **Assemble sources.** Pull the matching section from `Jon's Notes on SpudCell.md` + fetch the corresponding protobiology.org/spudcell.php protocol (WebFetch). Note which numbers are still missing → hand to **Plan 2** (manuscript).
 2. **I draft `[TECH]` slots.** Materials tables as inline `bom-<slug>` tables (per `build-boms` skill + migrate-content rules: 0-indent tables, `MW (g/mol)` paren units, DOI citations as full links, discrepancy `:::{warning}` blocks).
-3. **Cross-repo DNA check.** Any construct named (aHL-6xHis, aHL-FLAG, pREP, pLD1–3) → verify against `nucleus-eng/DNA`; if absent, `:::{attention}` gap block (do **not** invent filenames). Most SpudCell constructs are *not* in the repo yet (see spec L145) → expect attention blocks.
+3. **Cross-repo DNA check.** Use **Plan 2, section D** (the construct-by-construct verification table) as the source of truth for which constructs are in `nucleus-eng/DNA` and which need an `:::{attention}` gap block — don't re-derive this per page.
 4. **You fill `[HUMAN]` slots.** I leave `<!-- HUMAN: ... -->` prompts at each.
 5. **Wire it in** (see D).
 6. **QA** — Plan 3's gauntlet, scoped to the new file.

--- a/.claude/plans/spudcell/01-new-pages.md
+++ b/.claude/plans/spudcell/01-new-pages.md
@@ -1,0 +1,84 @@
+# Plan 1 — New pages (migrate technical, you write humanistic)
+
+**Goal.** Resolve the SpudCell-spec TODOs that are really "a page that doesn't exist yet." For each, we build a shared template that separates **technical slots** (I migrate from your notes + protobiology.org) from **humanistic slots** (you write). This plan covers the *page inventory*, the *template*, the *migration workflow*, and the *wiring* (TOC + index).
+
+Source of the split: your own `Jon's Notes on Module Specs.md` — a spec captures **Technical Details** (composition, conditions, part numbers, expected behavior) *and* **Humanistic Information** (contextual, operational, empathetic). I fill the former; you own the latter.
+
+---
+
+## A. Page inventory
+
+Every "(TODO link)" in `spudcell-spec.md` points at one of these. Classified as **process** (step-by-step protocol, `docs/processes/<slug>/main.md`) or **module** (spec, `docs/modules/<slug>/spec.md`).
+
+| # | Page | Type | Resolves spec TODO(s) | Primary source(s) |
+| --- | --- | --- | --- | --- |
+| P1 | **Encapsulation: Mechanical Extrusion** | process | L164 "Assembly and encapsulation… (TODO link)" | Notes-SpudCell §"Liposome Size Control (Extrusion Parameters)" (2 µm cell / 0.8 µm DLS / 0.4 µm feeder); protobiology "Encapsulation method" |
+| P2 | **Synthetic Cell Cycle: Growth & Division** | process | L14 process link; L12 "growth module (TODO)" + "cell division module (TODO)"; L150 "Feeding (TODO link)"; L165 dangling "see " | Notes-SpudCell §"Growth and division system", §"Feeding", §(4); protobiology "Synthetic Cell Cycle with Feeder Liposome Growth and Mechanical Division" |
+| P3 | **Feeder Liposome Prep & Fusion / FRET assay** | process | L150 feeding link (shared with P2); L63 azido/immobilization ("Methods §20") | Notes-SpudCell §"Feeding", §"Liposome Fusion Experiments", §"FRET…"; feeder-cell-spec.md already exists as the *module* side |
+| P4 | **(decision) Growth module + Division module as specs?** | module ×2 | L12 the two "module (TODO)" parentheticals — *if* you want them as first-class modules rather than sections of P2 | Notes-SpudCell §(3),(4); membrane-pore-ahly/spec.md is the reusable aHL base to extend |
+
+### Open decisions (yours — I'll build to whichever you pick)
+1. **Do "growth module" and "division module" become module specs (P4), or just anchor into the P2 process page?** Your Module-Specs notes lean toward modules-as-first-class (`Encapsulation: Mechanical Extrusion :> Encapsulation`), which argues for P4. But feeding/division may read better as one process. **Recommend:** P2 as the process + the growth/division *mechanisms* documented in `spudcell-spec.md`'s existing Expected Behavior section; only spin out P4 module specs if another cell will reuse them. Defer.
+2. **Is P3 separate from P2, or one big "cell cycle" process with sub-protocols?** Adamala's site splits them (Feeder Prep, Fusion, FRET, Cell Cycle are distinct protocols). **Recommend:** mirror that — P3 (+ FRET as a sub-page) feeds into P2. Defer.
+3. **`Encapsulation: Mechanical Extrusion` vs `: Phase Transfer`** — your notes flag both (mechanical extrusion for SpudCell; emulsion phase transfer / inverted emulsion is the other lineage). P1 is only the extrusion one; note the sibling exists but is out of scope here.
+
+---
+
+## B. The template (build together, once)
+
+One annotated skeleton per type, extending the existing `templates/process-template/` and `templates/module-template/`. Each section tagged:
+
+- **`[TECH]`** — I migrate verbatim-faithful technical content from notes/protobiology/manuscript. Tables, concentrations, catalog numbers, extrusion sizes, reaction conditions, construct refs, quantitative expected behavior.
+- **`[HUMAN]`** — you write. Overview framing, *why this matters*, design rationale, operational gotchas ("eater liposomes are limiting → every hungry mouth gets fed"), narrative, credits.
+- **`[BOTH]`** — I draft the skeleton/data, you add the judgment.
+
+Proposed process-page section map:
+```
+title (frontmatter)                      [TECH]
+# Overview                               [HUMAN]  ← the contextual/empathetic layer
+  :::{card} Important Information         [BOTH]
+    Notes / Prereqs / Hazards /          [HUMAN notes, TECH materials]
+    Critical Materials / GECs /
+    Composition / References
+# Protocol (## steps, - [ ] checkboxes)  [TECH]   ← operational, migrated from protobiology
+  :::{hint} extended notes               [HUMAN]
+# Downloads (PDF + BOM cards)            [TECH]
+```
+
+**Deliverable of step B:** `templates/spudcell-migration/process.md` + `.../module.md` (annotated). *Question for you:* keep these throwaway (delete after migration) or contribute them as reusable annotated templates? Leaning throwaway → put them under `.claude/plans/spudcell/templates/` so they don't ship.
+
+---
+
+## C. Migration workflow (per page)
+
+For each page P1–P3, in order:
+
+1. **Assemble sources.** Pull the matching section from `Jon's Notes on SpudCell.md` + fetch the corresponding protobiology.org/spudcell.php protocol (WebFetch). Note which numbers are still missing → hand to **Plan 2** (manuscript).
+2. **I draft `[TECH]` slots.** Materials tables as inline `bom-<slug>` tables (per `build-boms` skill + migrate-content rules: 0-indent tables, `MW (g/mol)` paren units, DOI citations as full links, discrepancy `:::{warning}` blocks).
+3. **Cross-repo DNA check.** Any construct named (aHL-6xHis, aHL-FLAG, pREP, pLD1–3) → verify against `nucleus-eng/DNA`; if absent, `:::{attention}` gap block (do **not** invent filenames). Most SpudCell constructs are *not* in the repo yet (see spec L145) → expect attention blocks.
+4. **You fill `[HUMAN]` slots.** I leave `<!-- HUMAN: ... -->` prompts at each.
+5. **Wire it in** (see D).
+6. **QA** — Plan 3's gauntlet, scoped to the new file.
+
+**Dependency:** P2/P3 feeding & genome numbers partly blocked on **Plan 2**. P1 (extrusion) is fully covered by notes → do P1 first as the template shakedown.
+
+---
+
+## D. Wiring each new page (don't forget)
+
+Per CLAUDE.md, a new page is never just the file:
+
+- **Process page:** add to `myst.yml` under `docs/processes/…` (`hidden: true` if a child); it appears via `processes-main.md`.
+- **Module spec (if P4):** *two* TOC updates — `myst.yml` entry **and** a row in `docs/modules/modules-main.md` (`Class | Spec | Validation ★`). SpudCell modules would be ★ (preliminary / preprint-only).
+- **Back-links:** replace the `(TODO link)` in `spudcell-spec.md` with the real relative `.md` link (never `.html`).
+- **File placement:** all under `docs/processes/<slug>/` or `docs/modules/<slug>/`; BOMs/images in `resources/`.
+
+---
+
+## E. Suggested order
+
+1. Build template (B) — quick, unblocks everything.
+2. **P1 Encapsulation: Mechanical Extrusion** — fully sourced from notes; proves the workflow end-to-end.
+3. **P3 Feeder prep / fusion / FRET** — mostly in notes; a few numbers → Plan 2.
+4. **P2 Synthetic Cell Cycle** — composes P1+P3; needs Plan 2 for genome/retention data.
+5. Revisit decision on **P4** modules once P2 exists.

--- a/.claude/plans/spudcell/02-manuscript-deep-dive.md
+++ b/.claude/plans/spudcell/02-manuscript-deep-dive.md
@@ -44,6 +44,31 @@
 
 ---
 
-## D. Deliverable
+## D. DNA repo verification
 
-`.claude/plans/spudcell/extraction.md` — the filled table + citations + flagged conflicts, ready for your sign-off. Feeds Plan 1 (P2/P3 numbers) and Plan 3 (genome-table unit normalization).
+Separate from manuscript extraction, but same treatment: a checkable table, not a buried QA step. Every construct named in `spudcell-spec.md`'s genome table (L130–139) needs its status confirmed against `nucleus-eng/DNA` before any new page (Plan 1) links to it or any attention block is written. Per CLAUDE.md: verify per-construct with `ls ~/src/nucleus-eng/DNA/<subdir>/<name>.gb` (or the `gh api` fallback if the repo isn't cloned locally) — never invent a filename or link to a legacy/bnext repo.
+
+| Construct | Spec claim (L130–139) | Expected subdir | Status | Action |
+| --- | --- | --- | --- | --- |
+| `pLD1` | 30.1 kb; PURE genes (subset of 30/36) | `PURE/cloning/` or `PURE/expression/` | Not yet in `nucleus-eng/DNA` (per spec L145–146) — **confirm still true** | If absent: attention block, flag for submission |
+| `pLD2` | length TODO (M1); PURE genes | same | Not yet in `nucleus-eng/DNA` — **confirm** | Same |
+| `pLD3` | length TODO (M1); PURE genes | same | Not yet in `nucleus-eng/DNA` — **confirm** | Same |
+| `T7RNAP` | T7 RNA polymerase | `PURE/cloning/` | **Matches** — [`pOpen-T7RNAP.gb`](https://github.com/nucleus-eng/DNA/blob/main/PURE/cloning/pOpen-T7RNAP.gb) already linked in spec | Re-verify file still exists at that path (DNA repo evolves independently — check `git -C ~/src/nucleus-eng/DNA log --oneline -5` first) |
+| `pREP` (Phi29 DNAP) | Phi29 DNA polymerase | new subdir? (no `Phi29/` or `replication/` dir exists yet) | Not yet in `nucleus-eng/DNA` — **confirm**; also flag that no matching subdir category currently exists | Attention block + note the DNA repo may need a new subdir, not just a new file (out of scope for nucleus-docs, but worth flagging to whoever owns DNA) |
+| `aHL-6xHis` | growth pore, 6xHis-tagged aHL | `detectors/` or new `membrane/` category? | Not yet in `nucleus-eng/DNA` — **confirm**. Note: base aHL exists as `membrane-pore-ahly` *module* in nucleus-docs, but that's the module spec, not the DNA construct file | Check if an untagged aHL `.gb` exists that this is a variant of; attention block regardless |
+| `aHL-FLAG` | division pore, FLAG-tagged aHL; 10 nM template | same | Not yet in `nucleus-eng/DNA` — **confirm** | Same as above |
+| `FP` (GFP reporter) | 2,500 (unit ambiguous — bp not kb, see Plan 3 F7) | `reporters/` | **Matches** — [`pOpen-deGFP.gbk`](https://github.com/nucleus-eng/DNA/blob/54a07a3d65edc1a348a462cff170dd17d11f26c6/reporters/pOpen-deGFP.gbk) or any reporter pair per spec L146 | Confirm which specific reporter the manuscript actually used (deGFP vs. a specific GFP variant) — spec currently hedges with "or any green/red reporter pair" |
+
+**Known count problem (ties to Plan 3 F2):** spec text says "five of seven plasmids" lack a match but lists **six** names (`pLD1, pLD2, pLD3, pREP, aHL-6xHis, aHL-FLAG`), against "two matching" (`FP`, `T7RNAP`) — six + two = eight, not seven. This table's per-construct check will settle the real count as a side effect; feed the corrected number back into Plan 3's F2 fix.
+
+**Method:**
+1. Check DNA repo recency: `git -C ~/src/nucleus-eng/DNA log --oneline -5` (or `gh api repos/nucleus-eng/DNA/commits` if not cloned) — confirm nothing's landed since this table was last true.
+2. For each row, `ls` the expected path; if absent, browse the likely subdir (`gh api "repos/nucleus-eng/DNA/contents/<subdir>"`) in case it's filed under an unexpected name.
+3. Record verified/absent status here, not scattered across page migrations — this table is the single source of truth for attention-block placement in Plan 1's pages and in `spudcell-spec.md` itself.
+4. **Do not** submit anything to `nucleus-eng/DNA` from this repo — out of scope per CLAUDE.md. This table only decides *whether nucleus-docs needs an attention block*.
+
+---
+
+## E. Deliverable
+
+`.claude/plans/spudcell/extraction.md` — the filled manuscript table (A) + the DNA verification table (D) + flagged conflicts, ready for your sign-off. Feeds Plan 1 (P2/P3 numbers + attention-block placement) and Plan 3 (genome-table unit normalization + the five-vs-six plasmid count fix).

--- a/.claude/plans/spudcell/02-manuscript-deep-dive.md
+++ b/.claude/plans/spudcell/02-manuscript-deep-dive.md
@@ -1,0 +1,49 @@
+# Plan 2 — Manuscript deep dive (fill the numbers the notes don't have)
+
+**Goal.** Close the *quantitative* TODOs in `spudcell-spec.md` that are not answerable from your notes and require the actual preprint + Methods + SI. Output is a **structured extraction table** you review — per the collaboration model, domain values are a hard-gate: I extract + cite, you confirm before they land.
+
+**Primary sources**
+- Preprint DOI `10.64898/2026.07.01.735724` (SpudCell / Adamala + Engelhart).
+- Protocols: `protobiology.org/spudcell.php` (protocol PDFs — the notes say the FRET assay and media are "fully expounded" here vs. terse in the paper).
+- Your notes already resolve a *surprising* amount — cross-check, don't re-derive.
+
+---
+
+## A. Extraction targets (mapped to spec location)
+
+| # | Spec location | What's missing | Where in paper | In notes already? |
+| --- | --- | --- | --- | --- |
+| M1 | Genome L120, table L132–139 | Total genome kb (confirm 90.3); **7 plasmid lengths** (only pLD1 = 30.1 kb, FP ≈ 2.5 kb known) | SI genome maps / plasmid table | pLD1 = 30.1 kb (~11 genes); FP = 2.5 kb (1 gene). Rest **TODO** |
+| M2 | Genome table L132–134 "which" | **Which PURE genes on pLD1 / pLD2 / pLD3** (30 of 36 split across three) | SI construct maps | "pLD1–pLD3 encode 30 of 36; T7RNAP separate; missing = AK, CK, NDK, PPiase". Per-plasmid split **TODO** |
+| M3 | Expected Behavior L154 / retention | Per-plasmid retention values | Fig 3o (30% retain all 7), Fig 3p (50% pLD1 → 70% aHL) | **Yes** — in notes; just needs transcription + fig citation |
+| M4 | Membrane table L49, functional L63 | **Azido lipid catalog/vendor** + stock conc + per-rxn volume | Methods §20 | "1 mol%, Methods §20" — **no catalog**. Biotin-NTA = VWR 90074 known |
+| M5 | Cytosol table L93 (empty part-# column) | Part numbers for HEPES, K-glutamate, Mg-glutamate, spermidine, creatine-P, folinic acid, AAs, rNTPs, dNTPs, DTT, PMix, tRNA, ribosomes | Methods §2 / reagents table | Phi29 = **Lucigen 30221-2** (known); NEB Sol B 60% v/v noted. Rest **TODO** |
+| M6 | Functional membrane L61–62 | aHL-6xHis / aHL-FLAG expression details; DNA vs protein; confirm 10 nM template | Methods (fusion tags) | aHL-FLAG 10 nM confirmed; sequences flagged as your own "JON TODO" |
+| M7 | Gen counter L116 | Top-strand (parent) / bottom-strand (feeder) delivery **method**; ligation chemistry | Methods §12 | Substantial: dsRNA oligos, T4 RNA/DNA ligase, 1 nM each, gen ≥ 3 readout, full energy-mix recipe. Confirm §12 details |
+| M8 | Cytosol "estimated" caveat L18, table L90 | Validate the **estimated** pREP concentrations vs. Methods §2 (remove "estimated" where confirmed) | Methods §2 + §13 media | Full estimated table in notes w/ the "Sol A = SMix" caveat (folinic acid †, DTT-for-TCEP). Needs paper confirmation |
+| M9 | Overview L25 + Behavior L154 | **Figures** — mechanism schematic (may build in BioRender) + a behavior/result figure | Figs 2, 3, 6 | none — need figure sourcing + **license check** |
+
+---
+
+## B. Method
+
+1. **Fetch** the preprint (WebFetch on the DOI landing page → PDF) and the protobiology protocol index. If the PDF isn't machine-readable, note it and fall back to the protocol pages, which your notes say are more complete anyway.
+2. **Extract into one table** keyed by the M# above: `value | unit | source (fig/§) | confidence | conflicts-with-notes?`.
+3. **Discrepancy flag** (migrate-content rule): where the paper disagrees with your notes or the current spec (e.g. "31 of 36" vs "30 of 36 + T7RNAP" vs spec's "pLD1–pLD3 encode 30 of 36"; genome "90 kb" vs "90.3 kb"; SpudCell.md's "34/38 genes" — a *third* number), surface all values side by side, don't silently pick one.
+4. **License gate for figures (M9).** Before reusing any paper figure, confirm the preprint license (CC-BY?). If not reusable, plan an original BioRender schematic instead (the mechanism schematic at L25 is ours to draw regardless). Do not commit vendor/paper PDFs (CLAUDE.md).
+5. **Hand back** the table for your confirmation; only then do I write values into the spec / new pages.
+
+---
+
+## C. Known conflicts to resolve first (don't paper over)
+
+- **Gene count:** spec "seven plasmids / 30 of 36" · Notes "31 of 36 (−EF-Tu −metabolism)" · SpudCell.md "34/38 genes" · outline "30 of 36 PURE + T7RNAP." Pin the exact denominator (36 vs 38) and numerator against the SI.
+- **Genome size:** 90 kb vs 90.3 kb — trivial but pick the cited one.
+- **aHL division linker:** Notes §(4) prose says "aHL-6xHis → Ni-NTA-biotin → streptavidin" in one place but the growth+division demo uses "aHL-FLAG → biotin-antiFLAG → streptavidin." Spec uses aHL-FLAG. Confirm which pore carries which linker in the division regime (this is a real mechanism ambiguity, not just wording).
+- **"estimated" cytosol:** decide per-row whether the paper confirms it (drop "est.") or not (keep + caveat).
+
+---
+
+## D. Deliverable
+
+`.claude/plans/spudcell/extraction.md` — the filled table + citations + flagged conflicts, ready for your sign-off. Feeds Plan 1 (P2/P3 numbers) and Plan 3 (genome-table unit normalization).

--- a/.claude/plans/spudcell/03-formatting.md
+++ b/.claude/plans/spudcell/03-formatting.md
@@ -1,0 +1,52 @@
+# Plan 3 — Formatting & structural cleanup of `spudcell-spec.md`
+
+**Goal.** Fix the *structural* defects on the page — broken fences, dead cross-refs, unit/style violations — that are independent of the content TODOs. These I can do without new pages or manuscript data (a few are gated on Plans 1–2 and are marked). Line numbers reference the `spudcell` branch version.
+
+---
+
+## A. Broken MyST / rendering (fix first — these break the build or render wrong)
+
+| # | Line | Defect | Fix |
+| --- | --- | --- | --- |
+| F1 | 147 | Attention block closes with `::` instead of `:::` | Change `::` → `:::` |
+| F2 | 145–146 | Text says "**five** of seven" then lists **six** names (`pLD1, pLD2, pLD3, pREP, aHL-6xHis, aHL-FLAG`) — and the two "matching" (`FP`, `T7RNAP`) make 8 total vs "seven plasmids" | Recount vs Plan 2 M1/M2; fix the count + list (content-adjacent — confirm the real plasmid set) |
+| F3 | 67 | Two broken links: `[Synthetic Cell Media]` (reference-style link with no definition → renders literally) and `[SpudCell Cytosol](#Cytosol Competition)` (anchor has a space **and** wrong name — section is "Cytosol Composition", not "Competition"). Sentence also missing terminal period | Point first link to `./synthetic-cell-media-spec.md`; fix anchor to the real heading slug (`#cytosol-composition`); add period |
+| F4 | 50–51 | `See {ref}…` caption line sits *inside* the table fence after the rows — verify it renders as caption vs. leaks into the table | Move below `:::` or confirm intended |
+
+## B. Unit / style (Vale + codespell will flag)
+
+| # | Line | Defect | Fix |
+| --- | --- | --- | --- |
+| F5 | 73 | Table title "per 30 uL prep" — ASCII `u` | `µL` (nucleus.micro-symbol) |
+| F6 | 64 | "Fluorescent **labelled** lipids" — British | `labeled` (codespell en-GB→en-US) |
+| F7 | 132–139 | **Unit inconsistency** in genome table: lengths in **kb** (30.1) but `FP` row shows `2,500` (bp) | Normalize — either kb throughout (`2.5`) or add a unit column. Coordinate w/ Plan 2 M1 |
+| F8 | 12 | Double space: "90.3 kb,  seven" | single space |
+| F9 | 15–16 | Double blank line | single |
+
+> Run Vale/codespell to catch the rest — spot-checks only above. Watch for other `um`/`uL`/`uM` (notes use ASCII `u` heavily; some may have been pasted in), and ion/chemical notation if any crept in.
+
+## C. Empty-column / table-shape decisions (yours)
+
+| # | Line | Issue | Decision needed |
+| --- | --- | --- | --- |
+| F10 | 44 | Base-bilayer table has empty `TODO: links` column (all rows blank) | Fill catalog links or **drop the column**? |
+| F11 | 93 | Cytosol table has **two** TODO header cells (`Notes TODO…`, `TODO: part numbers…`) with fully empty columns | Part-# column is Plan 2 (M5); the *Notes* column already has content mid-table — clean the header. Decide final column set |
+
+## D. Gated on other plans (don't fix in isolation)
+
+- **L162–165 "Protocols" section** — L165 dangling "see " and L164 "(TODO link)". Structural fix = insert the real links, but the *targets don't exist yet* → resolved by **Plan 1** (P1/P2). Leave a single `<!-- TODO: link after Plan 1 -->` for now rather than a half-sentence.
+- **L25 / L154 figure placeholders** — **Plan 2** M9 (sourcing/license) + possible BioRender build. Per CLAUDE.md, mechanism schematic belongs in Overview (✓ L25), system-in-context figure belongs in a `## Cells` section (none exists yet — flag if we add one).
+
+## E. QA gauntlet (run before PR; scope to this file where possible)
+
+```bash
+conda run -n nucleus-docs myst build --html          # confirm ONE bibliography block renders
+python3 scripts/check-dropdowns.py                    # placeholder-only lists (spec TODOs are inline/table, likely OK — confirm)
+python3 scripts/check-formatting.py docs/modules/spudcell/spudcell-spec.md
+python3 scripts/check-toc.py
+vale docs/modules/spudcell/spudcell-spec.md
+codespell docs/modules/spudcell/spudcell-spec.md
+python3 scripts/check-links.py docs/modules/spudcell/spudcell-spec.md   # after F3 link fixes
+```
+
+**Order:** A (rendering) → B (units) → C (decide w/ you) → E (verify) → D last (unblocked by Plans 1–2).


### PR DESCRIPTION
Three planning docs (in `.claude/plans/spudcell/`, so they don't ship to the site or trip `check-file-placement`) that decompose the `spudcell-spec.md` TODOs into workstreams:

1. **`01-new-pages.md`** — the "(TODO link)" TODOs are really *pages that don't exist yet* (encapsulation, cell cycle, feeder prep). Workflow: build a shared migration template, I migrate technical detail from your notes + protobiology.org, you write the humanistic context. Anchored on your `Jon's Notes on Module Specs.md` technical/humanistic split. Includes page inventory, open page-boundary decisions, and TOC/index wiring.
2. **`02-manuscript-deep-dive.md`** — the quantitative TODOs your notes *don't* cover (per-plasmid genome lengths, PURE-gene split, azido-lipid catalog, cytosol part numbers, figure licensing). Extraction-table method with discrepancy flagging + known conflicts to resolve.
3. **`03-formatting.md`** — structural cleanup of the spec page (broken `::` fence, dead cross-refs on L67, unit/spelling violations, empty-column decisions), with the QA gauntlet.

Draft — these are working plans for review, not content changes. No `docs/` files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)