### PR TITLE
fix(check-links): classify link failures by meaning, not by vendor

### DIFF
--- a/.claude/skills/lint-docs.md
+++ b/.claude/skills/lint-docs.md
@@ -92,13 +92,37 @@ codespell only flags words in its curated misspelling dictionary, so niche techn
 
 ### Link checking (lychee)
 
-**Run `python3 scripts/check-links.py docs/` before opening a PR if you have added, edited, or removed any links or URLs.** This is slower than Vale and doesn't need to run on every commit — focus on PRs that touch links.
+**Run `python3 scripts/check-links.py docs/` before opening a PR if you have added, edited, or removed any links or URLs.** Takes ~20 s for the whole corpus.
 
 ```bash
-python3 scripts/check-links.py docs/       # check all docs
-python3 scripts/check-links.py <file.md>   # check a single file
+python3 scripts/check-links.py docs/                  # both passes over all docs
+python3 scripts/check-links.py <file.md>              # both passes, one file
+python3 scripts/check-links.py --offline-only docs/   # internal links only, no network (~0.05 s)
 ```
 
-The script wraps `lychee` and filters known false positives before reporting. **What it catches:** dead internal links, 404 external links, empty URLs. **What it does not catch:** product catalog changes on vendor sites (e.g. Sigma-Aldrich discontinuing a part number) — those require manual review.
+The script wraps `lychee` and runs two passes: an **offline pass** over internal/relative links, and a **network pass** over external URLs.
 
-**Interpreting output.** The script will note how many HTTP/2 false positives were filtered from `sigmaaldrich.com` — these are valid URLs on a server that blocks automated crawlers at the protocol level and can be ignored. Any remaining errors are genuine and should be fixed before opening a PR.
+**Exit codes.** `0` nothing blocking · `1` broken links · `2` the check could not run (lychee missing, unparsable output). Exit 2 is deliberately distinct — a broken toolchain must not read as broken docs.
+
+**Interpreting output.** A failure is judged by what it says about the link, not by which vendor served it:
+
+| Signal | Verdict |
+| --- | --- |
+| HTTP 404 or 410 | **blocking** — the resource is gone |
+| Hostname does not resolve | **blocking** — typo'd or dead domain |
+| Relative/root-relative link resolves to no file | **blocking** — this 404s the deployed site |
+| HTTP 401, 403, 429, any 5xx | tolerated, reported — crawler refused or server hiccup |
+| Any other 4xx (400, 405, 406, 451…) | tolerated, reported — bot-shaped rejection |
+| Timeout, TLS error, HTTP/2 reset, connection reset | tolerated, reported — says nothing about link validity |
+
+**Tolerated failures are expected, not actionable.** A clean run reports ~120 of them — Sigma-Aldrich and Cytiva reset HTTP/2 connections at the protocol level, and many vendors plus `doi.org` return 403 to crawlers. They are summarized by host and reason. `✅ no broken links` printed under a long tolerated list is a **pass**; report it as one.
+
+**Do not add a suppression list.** There deliberately isn't one. The previous version kept a per-domain allowlist keyed on the literal string `HTTP/2 protocol error`, which meant every newly crawler-hostile vendor turned the PR gate red until someone landed a config change (issues #193, #199). If you find yourself wanting to name a vendor in `.lychee.toml` or the script, the classifier needs fixing instead.
+
+**Blame partitioning.** CI passes `--blame-changed <base-ref>`, so external rot only blocks the PR when it sits in a file the PR modified. Pre-existing rot elsewhere prints under a "pre-existing broken link(s)" heading without failing the build; the weekly `link-rot` workflow tracks it in a single GitHub issue. Internal-link failures block regardless. Local runs omit the flag, so everything blocks.
+
+**What it does not catch.** Staleness detection only works where a vendor returns an honest status code:
+- **Sigma-Aldrich and Cytiva never return one** (~40% of external links) — a discontinued part number there is undetectable at any frequency.
+- **Soft-404s are invisible** — "product not found" served with HTTP 200 reads as healthy.
+
+Both still need manual review; don't tell the developer the link check clears them.

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -4,16 +4,41 @@ on:
   pull_request:
     branches: [main]
 
+# Link checking is split by what a failure means (see scripts/check-links.py):
+#
+#   * Internal links are ours to get right and a break 404s the deployed site,
+#     so any internal failure blocks — no matter which files the PR touched.
+#   * External links are checked across the whole corpus every run (that is what
+#     makes this a staleness check), but only rot in files this PR *modified*
+#     blocks it. Pre-existing rot elsewhere is reported here and tracked by the
+#     weekly link-rot workflow, so a vendor's catalog churn cannot block an
+#     unrelated PR.
+#   * Vendor noise (403/429/5xx/timeout/TLS/HTTP-2 reset) never blocks anything.
+#     See issues #193 and #199.
 jobs:
   check-links:
     runs-on: ubuntu-latest
+    env:
+      LYCHEE_VERSION: "0.24.2"
     steps:
+      # Full history so the base-ref diff behind --blame-changed resolves.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
+      # Pinned deliberately: lychee's JSON report is this check's input contract,
+      # and its shape has changed between releases before (issue #136). Tracking
+      # `latest` meant CI could classify differently than any developer's local
+      # run. Bump this in step with the local install documented in setup.sh.
       - name: Install lychee
         run: |
-          curl -sSL https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz \
+          set -euo pipefail
+          curl -sSL "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" \
             | tar xz --strip-components=1 -C /usr/local/bin lychee-x86_64-unknown-linux-gnu/lychee
+          lychee --version
 
       - name: Check links
-        run: python3 scripts/check-links.py docs/
+        run: |
+          python3 scripts/check-links.py \
+            --blame-changed "origin/${{ github.base_ref }}" \
+            docs/

--- a/.github/workflows/link-rot.yml
+++ b/.github/workflows/link-rot.yml
@@ -1,0 +1,94 @@
+name: Link Rot Sweep
+
+# Whole-corpus link check against main, on a schedule rather than per-PR.
+#
+# The PR check (check-links.yml) deliberately does not block on rot in files the
+# PR did not touch — otherwise a vendor retiring a catalog page would block every
+# open PR, which is the problem issues #193 and #199 were about. That rot still
+# needs to be found and fixed, so this job owns it: it runs unpartitioned (every
+# broken link counts) and keeps a single tracking issue up to date.
+#
+# Issue filing lives here, not in the PR workflow, because a pull_request run
+# cannot do it reliably — fork PRs get a read-only token, and every re-run would
+# open another duplicate.
+
+on:
+  schedule:
+    # Mondays, 06:00 UTC.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    env:
+      LYCHEE_VERSION: "0.24.2"
+      GH_TOKEN: ${{ github.token }}
+      LABEL: link-rot
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pinned to match check-links.yml and the local install — see the comment
+      # there for why.
+      - name: Install lychee
+        run: |
+          set -euo pipefail
+          curl -sSL "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" \
+            | tar xz --strip-components=1 -C /usr/local/bin lychee-x86_64-unknown-linux-gnu/lychee
+          lychee --version
+
+      - name: Sweep links
+        id: sweep
+        run: |
+          set +e
+          python3 scripts/check-links.py docs/ 2>&1 | tee sweep.txt
+          echo "status=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure tracking label exists
+        run: gh label create "$LABEL" --color B60205 --description "Broken external links found by the weekly sweep" --force
+
+      - name: File or update the tracking issue
+        if: steps.sweep.outputs.status == '1'
+        run: |
+          set -euo pipefail
+          {
+            echo "The weekly link sweep found broken links on \`main\`."
+            echo
+            echo "These are hard failures — a 404/410, or a hostname that no longer resolves."
+            echo "Vendor noise (403/429/5xx/timeouts/HTTP-2 resets) is excluded by design; see"
+            echo "\`scripts/check-links.py\`."
+            echo
+            echo "Updated by [run #${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) — this issue is edited in place, so it always reflects the latest sweep."
+            echo
+            echo '```'
+            cat sweep.txt
+            echo '```'
+          } > body.md
+
+          existing=$(gh issue list --label "$LABEL" --state open --limit 1 --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --body-file body.md
+            echo "Updated issue #$existing"
+          else
+            gh issue create --title "Broken links found on main" --label "$LABEL" --body-file body.md
+          fi
+
+      - name: Close the tracking issue when clean
+        if: steps.sweep.outputs.status == '0'
+        run: |
+          set -euo pipefail
+          existing=$(gh issue list --label "$LABEL" --state open --limit 1 --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue close "$existing" --comment "The weekly sweep now passes — no broken links remain. Closing automatically."
+          fi
+
+      - name: Fail if the sweep could not run
+        if: steps.sweep.outputs.status == '2'
+        run: |
+          echo "::error::check-links.py could not run (exit 2) — tooling problem, not link rot."
+          cat sweep.txt
+          exit 1

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,12 +1,19 @@
 # .lychee.toml — lychee link checker configuration
-# Run locally: lychee docs/
+# Run locally: python3 scripts/check-links.py docs/
 # See: https://lychee.cli.rs/
+#
+# Failure *classification* lives in scripts/check-links.py, not here. This file
+# only controls how requests are made. In particular, do not add a vendor's
+# status code to `accept` to quiet a noisy site — the wrapper already tolerates
+# the whole "our crawler was refused / the server hiccuped" class, and accepting
+# a status here would also hide it from the wrapper's report.
 
-# Accepted HTTP status codes.
-# Explicitly restates the lychee default (100..=103, 200..=299) plus 403.
-# 403 is expected for academic papers and some vendor pages behind paywalls —
-# a 403 on a DOI or journal link does not mean the link is broken.
-accept = ["100..=103", "200..=299", "403"]
+# Accepted HTTP status codes — the lychee default (100..=103, 200..=299).
+#
+# 403 used to be listed here, which made every "crawler refused" response
+# silently count as a success. The wrapper handles it now, so a 403 is tolerated
+# *and reported* rather than being invisible.
+accept = ["100..=103", "200..=299"]
 
 # Root directory for resolving root-relative links (e.g. /docs/modules/foo/spec.md).
 # MyST supports root-relative paths as valid cross-page links; without this,
@@ -14,15 +21,23 @@ accept = ["100..=103", "200..=299", "403"]
 # Run lychee from the repo root for this to work correctly.
 root_dir = "."
 
-# Note: sigmaaldrich.com terminates HTTP/2 connections at the protocol level,
-# returning no HTTP status code. check-links.py filters these out specifically
-# so genuine dead Sigma links (DNS failure, 404, etc.) are still caught.
-
 # Request timeout in seconds
 timeout = 20
 
 # Maximum number of redirects to follow
 max_redirects = 10
+
+# Be gentle with individual vendors. lychee defaults to 10 concurrent requests
+# per host, so a vendor with a dozen catalog links in one BOM gets a burst of
+# parallel traffic — enough for some of them (sonicator.com, issue #193) to
+# answer 503/504 that a browser never sees. Lower concurrency plus a longer
+# inter-request delay than the 50 ms default makes those responses much rarer.
+host_concurrency = 4
+host_request_interval = "200ms"
+
+# Wait longer between retries than the default 1 s so a transient 5xx has time
+# to clear. max_retries stays at its default of 3.
+retry_wait_time = 3
 
 # Skip mailto: links
 include_mail = false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,14 +351,36 @@ codespell only flags words in its curated misspelling dictionary, so niche techn
 
 ### Link checking (lychee)
 
-**Run `python3 scripts/check-links.py docs/` before opening a PR if you have added, edited, or removed any links or URLs.** This is slower than Vale and doesn't need to run on every commit — focus on PRs that touch links.
+**Run `python3 scripts/check-links.py docs/` before opening a PR if you have added, edited, or removed any links or URLs.** Takes ~20 s for the whole corpus.
 
 ```bash
-python3 scripts/check-links.py docs/       # check all docs
-python3 scripts/check-links.py <file.md>   # check a single file
+python3 scripts/check-links.py docs/          # both passes over all docs
+python3 scripts/check-links.py <file.md>      # both passes, one file
+python3 scripts/check-links.py --offline-only docs/   # internal links only, no network (~0.05 s)
 ```
 
-The script wraps `lychee` and filters known false positives before reporting. **What it catches:** dead internal links, 404 external links, empty URLs. **What it does not catch:** product catalog changes on vendor sites (e.g. Sigma-Aldrich discontinuing a part number) — those require manual review.
+The script wraps `lychee` and runs two passes: an **offline pass** over internal/relative links, and a **network pass** over external URLs. Exit codes are `0` (nothing blocking), `1` (broken links), `2` (the check could not run — e.g. lychee missing; distinct so tooling breakage isn't mistaken for broken docs).
+
+**A failure is judged by what it says about the link, not by which vendor served it.** Do not add vendor domains or status codes to a suppression list — there isn't one, deliberately (issues #193, #199).
+
+| Signal | Verdict |
+| --- | --- |
+| HTTP 404 or 410 | **blocking** — the resource is gone |
+| Hostname does not resolve | **blocking** — typo'd or dead domain |
+| Relative/root-relative link resolves to no file | **blocking** — this 404s the deployed site |
+| HTTP 401, 403, 429, any 5xx | tolerated, reported — crawler refused or server hiccup |
+| Any other 4xx (400, 405, 406, 451…) | tolerated, reported — bot-shaped rejection |
+| Timeout, TLS error, HTTP/2 reset, connection reset | tolerated, reported — says nothing about link validity |
+
+Tolerated failures are normal and expected: a clean run currently reports ~120 of them (Sigma-Aldrich and Cytiva reset HTTP/2 connections; many vendors and `doi.org` return 403 to crawlers). **`✅ no broken links` alongside a long tolerated list is a pass.**
+
+**Blame partitioning.** In CI the check runs with `--blame-changed <base-ref>`: external rot only blocks the PR if it's in a file the PR modified. Pre-existing rot elsewhere is reported under a "pre-existing broken link(s)" heading without failing the build, and is tracked by the weekly `link-rot` workflow, which keeps a single GitHub issue up to date. Internal-link failures block regardless of which files changed. Local runs omit the flag, so everything blocks.
+
+**What it does not catch.** Staleness detection only works where a vendor returns an honest status code, so its reach is narrower than it looks:
+- **Sigma-Aldrich and Cytiva never return one** — they reset the connection before any HTTP status. Between them that's ~40% of external links, and a discontinued part number there is undetectable at any frequency.
+- **Soft-404s are invisible** — a vendor serving "product not found" with HTTP 200 reads as a healthy link.
+
+Both still require manual review. `lychee` is pinned to 0.24.2 in both workflows because its JSON report is this script's input contract and has changed shape between releases before (#136); bump the pin and the local install together.
 
 **Before opening a PR or committing content**, run Vale + codespell (and the link checker if you touched any URLs). Invoke the `lint-docs` skill for exact commands and how to interpret each tool's output — including which Vale errors are real vs. false positives.
 

--- a/scripts/check-links.py
+++ b/scripts/check-links.py
@@ -1,131 +1,391 @@
 #!/usr/bin/env python3
 """
-check-links.py — lychee wrapper that filters known vendor HTTP/2 false positives.
+check-links.py — lychee wrapper that classifies link failures by what they
+actually tell you about the link.
 
-Some vendor sites (e.g. sigmaaldrich.com) terminate HTTP/2 connections at the
-protocol level before returning any HTTP status code. This produces a
-"Network error: HTTP/2 protocol error" in lychee's output that cannot be
-distinguished from a real error via lychee config alone.
+Two passes, both over the whole corpus:
 
-This script runs lychee with JSON output, filters out errors that match the
-known HTTP/2 false-positive pattern for excluded domains, and exits non-zero
-only if genuine errors remain.
+  Pass A (internal)  lychee --offline. Relative and root-relative links only, no
+                     network. Deterministic and fast (~20 ms for all of docs/).
+                     A broken internal link 404s the deployed site, so any
+                     failure here blocks unconditionally.
+
+  Pass B (external)  Network check. Every failure is classified as either a HARD
+                     FAIL (the link is wrong) or TOLERATED noise (our bot was
+                     blocked, or the server hiccuped).
+
+The classification axis is what the response says about the *link*, not which
+vendor served it:
+
+  * A 404/410, or a hostname that does not resolve, means the link is wrong.
+    Deterministic and actionable — hard failure.
+  * A 403/429/5xx/timeout/TLS error/HTTP-2 reset means the crawler was refused
+    or the server had a bad moment. It says nothing about whether the link is
+    valid, and it is not reproducible — tolerated, but reported.
+
+This replaces an earlier per-domain allowlist keyed on the literal string
+"HTTP/2 protocol error", which meant every newly crawler-hostile vendor turned
+the PR gate red until someone landed a config change (issues #193, #199).
+
+Blame partitioning: with --blame-changed, only hard failures in files the branch
+modified affect the exit status. Pre-existing rot elsewhere is still found and
+reported, but does not block a PR that did not cause it. The scheduled link-rot
+sweep runs without the flag, so there every hard failure counts.
 
 Usage:
-    python3 scripts/check-links.py [lychee args...]
-    python3 scripts/check-links.py docs/
-    python3 scripts/check-links.py --no-progress docs/
+    python3 scripts/check-links.py                    # both passes over docs/
+    python3 scripts/check-links.py docs/ templates/   # both passes, given paths
+    python3 scripts/check-links.py <file.md>          # both passes, one file
+    python3 scripts/check-links.py --offline-only     # Pass A alone (no network)
+    python3 scripts/check-links.py --blame-changed origin/main docs/
+
+Exit codes:
+    0  no blocking failures (tolerated noise and non-blocking rot may be listed)
+    1  blocking link failures found
+    2  the check could not run (lychee missing, or unparsable output)
 """
 
 import json
 import shutil
+import socket
 import subprocess
 import sys
-import tomllib
-from pathlib import Path
+from collections import Counter, defaultdict
+from functools import lru_cache
+from urllib.parse import urlsplit
 
-HTTP2_ERROR_SUBSTRING = "HTTP/2 protocol error"
+LYCHEE_CONFIG = ".lychee.toml"
 
-_CONFIG_PATH = Path(__file__).with_name("link-false-positives.toml")
+EXIT_OK = 0
+EXIT_FAILURES = 1
+EXIT_CANNOT_RUN = 2
 
-def _load_false_positive_domains() -> list[str]:
-    try:
-        with _CONFIG_PATH.open("rb") as f:
-            data = tomllib.load(f)
-    except FileNotFoundError:
-        return []
-    return data.get("http2_false_positives", {}).get("domains", [])
+# Status codes that mean the resource is gone — the link itself is wrong.
+DEAD_CODES = {404, 410}
 
-
-HTTP2_FALSE_POSITIVE_DOMAINS = _load_false_positive_domains()
-
-
-def is_http2_false_positive(url: str, error_text: str) -> bool:
-    return (
-        any(domain in url for domain in HTTP2_FALSE_POSITIVE_DOMAINS)
-        and HTTP2_ERROR_SUBSTRING in error_text
-    )
+# Verdicts
+HARD_FAIL = "hard_fail"
+TOLERATED = "tolerated"
 
 
-def main():
+class CannotRun(Exception):
+    """lychee could not be run, or produced output we cannot interpret."""
+
+
+def _run_lychee(args: list[str], offline: bool) -> dict:
+    """Run lychee and return its parsed JSON report."""
     if not shutil.which("lychee"):
-        print("ERROR: lychee is not installed. Run ./setup.sh or: brew install lychee")
-        sys.exit(1)
+        raise CannotRun(
+            "lychee is not installed. Run ./setup.sh or: brew install lychee"
+        )
 
-    args = sys.argv[1:] or ["docs/"]
+    cmd = ["lychee", "--config", LYCHEE_CONFIG, "--format", "json", "--no-progress"]
+    if offline:
+        cmd.append("--offline")
+    cmd += args
 
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    # lychee appends free-text hints after the JSON document, so decode just the
+    # first JSON value rather than depending on the exact hint wording.
+    start = result.stdout.find("{")
+    if start == -1:
+        raise CannotRun(
+            "lychee produced no JSON output.\n"
+            f"exit={result.returncode}\n"
+            f"stdout: {result.stdout[:500]}\n"
+            f"stderr: {result.stderr[:500]}"
+        )
+    try:
+        report, _ = json.JSONDecoder().raw_decode(result.stdout[start:])
+    except json.JSONDecodeError as exc:
+        raise CannotRun(
+            f"could not parse lychee JSON output: {exc}\n"
+            f"stdout: {result.stdout[:500]}"
+        ) from exc
+    return report
+
+
+@lru_cache(maxsize=None)
+def host_resolves(host: str) -> bool:
+    """Whether a hostname resolves in DNS.
+
+    lychee reports a mistyped hostname and a vendor closing the connection with
+    the *same* code-less "Connection failed" error, so the JSON alone cannot
+    tell "this domain does not exist" (a real authoring mistake) from "this
+    server hung up on our crawler" (noise). Resolving the name settles it.
+    """
+    if not host:
+        return False
+    try:
+        socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        return False
+    except OSError:
+        # Anything other than a resolution failure (e.g. no network at all) is
+        # not evidence that the domain is dead — do not blame the link for it.
+        return True
+    return True
+
+
+def classify(entry: dict) -> tuple[str, str]:
+    """Classify one lychee error entry as (verdict, reason).
+
+    Entries whose status carries no code and no recognizable detail — lychee's
+    "Error (cached)" repeats — return a verdict of None so the caller can make
+    them inherit the verdict already established for that URL.
+    """
+    status = entry.get("status", {})
+    code = status.get("code")
+
+    if code is not None:
+        if code in DEAD_CODES:
+            return HARD_FAIL, f"HTTP {code} — resource is gone"
+        return TOLERATED, f"HTTP {code}"
+
+    url = entry.get("url", "")
+    split = urlsplit(url)
+
+    if split.scheme == "file":
+        # A relative or root-relative link that resolves to nothing on disk.
+        # This is the failure that 404s the deployed site.
+        return HARD_FAIL, "local file not found"
+
+    host = split.hostname or ""
+    if not host:
+        return HARD_FAIL, "no host in URL"
+
+    if not host_resolves(host):
+        return HARD_FAIL, f"{host} does not resolve"
+
+    detail = status.get("details") or status.get("text") or "network error"
+    return TOLERATED, detail
+
+
+def _is_detail_less(entry: dict) -> bool:
+    """True for lychee's stripped 'Error (cached)' repeats.
+
+    When the same URL appears in several files, lychee reports the repeats from
+    its in-run cache with the status detail removed. Those entries carry no
+    information of their own and must inherit the verdict established for the
+    URL elsewhere in the report.
+    """
+    status = entry.get("status", {})
+    if status.get("code") is not None:
+        return False
+    text = (status.get("text") or "").strip()
+    return "cached" in text.lower() and not status.get("details")
+
+
+def collect_findings(report: dict) -> list[dict]:
+    """Flatten a lychee report into classified findings.
+
+    Reads error_map and timeout_map. Timeouts live in their own bucket and are
+    absent from error_map, so a wrapper that reads only error_map drops them
+    silently — which is what happened before this rewrite.
+    """
+    raw = []
+    for filepath, entries in report.get("error_map", {}).items():
+        for entry in entries:
+            raw.append((filepath, entry, None))
+    for filepath, entries in report.get("timeout_map", {}).items():
+        for entry in entries:
+            raw.append((filepath, entry, "request timed out"))
+
+    # First pass: classify everything that carries its own information.
+    verdict_by_url: dict[str, str] = {}
+    classified = []
+    for filepath, entry, forced_reason in raw:
+        url = entry.get("url", "")
+        if forced_reason is not None:
+            verdict, reason = TOLERATED, forced_reason
+        elif _is_detail_less(entry):
+            verdict, reason = None, "cached repeat"
+        else:
+            verdict, reason = classify(entry)
+
+        if verdict == HARD_FAIL:
+            # A hard verdict for a URL applies to every occurrence of that URL,
+            # including detail-less repeats in other files.
+            verdict_by_url[url] = HARD_FAIL
+        elif verdict == TOLERATED:
+            verdict_by_url.setdefault(url, TOLERATED)
+
+        classified.append((filepath, entry, verdict, reason))
+
+    # Second pass: resolve inheritance, then apply URL-level hard verdicts.
+    findings = []
+    for filepath, entry, verdict, reason in classified:
+        url = entry.get("url", "")
+        known = verdict_by_url.get(url)
+        if verdict is None:
+            # Unknown on its own; inherit. Default to tolerated rather than
+            # inventing a failure from an entry that carries no evidence.
+            verdict = known or TOLERATED
+            reason = f"{reason} (inherited: {verdict})"
+        elif known == HARD_FAIL:
+            verdict = HARD_FAIL
+        findings.append(
+            {
+                "file": filepath,
+                "url": url,
+                "line": entry.get("span", {}).get("line", "?"),
+                "verdict": verdict,
+                "reason": reason,
+            }
+        )
+    return findings
+
+
+def changed_files(ref: str) -> set[str]:
+    """Files modified relative to ref. Empty set if git cannot answer."""
     result = subprocess.run(
-        ["lychee", "--config", ".lychee.toml", "--format", "json", "--no-progress", *args],
+        ["git", "diff", "--name-only", "--diff-filter=d", f"{ref}...HEAD"],
         capture_output=True,
         text=True,
     )
-
-    # lychee emits a trailing "Hint:" line after the JSON — strip it
-    json_text = result.stdout.split("\nHint:")[0].strip()
-
-    try:
-        report = json.loads(json_text)
-    except json.JSONDecodeError:
-        print("ERROR: could not parse lychee JSON output:")
-        print(result.stdout)
-        sys.exit(1)
-
-    # Filter error_map: remove known HTTP/2 false positives
-    genuine_errors = {}
-    filtered_count = 0
-
-    error_map = report.get("error_map", {})
-
-    # A vendor URL that produced the HTTP/2 protocol error anywhere in the report
-    # is a known crawler-block false positive. Newer lychee dedupes repeated URLs
-    # within a run and reports the repeats from cache with the HTTP/2 detail
-    # stripped (status collapses to a generic "Error (cached)"), so match by URL
-    # — not per-entry text — to catch those cached repeats too. Genuine dead
-    # links (404/DNS) never produce an HTTP/2 error, so they are never added here
-    # and stay reported.
-    http2_fp_urls = {
-        entry.get("url", "")
-        for entries in error_map.values()
-        for entry in entries
-        if is_http2_false_positive(
-            entry.get("url", ""), entry.get("status", {}).get("text", "")
+    if result.returncode != 0:
+        print(
+            f"⚠️  could not diff against {ref} "
+            f"({result.stderr.strip()}) — treating every failure as blocking",
+            file=sys.stderr,
         )
-    }
+        return None
+    return {line.strip() for line in result.stdout.splitlines() if line.strip()}
 
-    for filepath, entries in error_map.items():
-        real = []
-        for entry in entries:
-            if entry.get("url", "") in http2_fp_urls:
-                filtered_count += 1
-            else:
-                real.append(entry)
-        if real:
-            genuine_errors[filepath] = real
 
-    # Print summary
-    total_errors = sum(len(v) for v in genuine_errors.values())
-    excludes = report.get("excludes", 0)
+@lru_cache(maxsize=1)
+def _repo_root() -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _relative(path: str) -> str:
+    """lychee reports absolute paths for some inputs; git reports repo-relative."""
+    root = _repo_root()
+    if root and path.startswith(root + "/"):
+        return path[len(root) + 1 :]
+    return path
+
+
+def _print_group(heading: str, findings: list[dict]) -> None:
+    print(f"\n{heading}\n")
+    by_file = defaultdict(list)
+    for f in findings:
+        by_file[f["file"]].append(f)
+    for filepath, entries in sorted(by_file.items()):
+        print(f"  {_relative(filepath)}")
+        for f in sorted(entries, key=lambda e: str(e["line"])):
+            print(f"    [{f['line']}] {f['url']} — {f['reason']}")
+
+
+def _print_tolerated(findings: list[dict]) -> None:
+    """Summarize tolerated noise by host and reason rather than listing all of it."""
+    if not findings:
+        return
+    grouped = Counter(
+        (urlsplit(f["url"]).hostname or "?", f["reason"].split(" (inherited")[0])
+        for f in findings
+    )
+    total = len(findings)
+    print(f"\nℹ️  {total} tolerated failure(s) — blocked crawler or server hiccup,")
+    print("   not evidence of a broken link:\n")
+    for (host, reason), count in sorted(grouped.items(), key=lambda kv: -kv[1]):
+        print(f"    {count:4d}  {host}  —  {reason}")
+
+
+def _is_web(url: str) -> bool:
+    return urlsplit(url).scheme in ("http", "https")
+
+
+def run_pass(label: str, paths: list[str], offline: bool) -> list[dict]:
+    report = _run_lychee(paths, offline=offline)
+    findings = collect_findings(report)
+
+    # The two passes overlap: the network pass also resolves internal links, so
+    # without this a broken relative link would be reported by both. Pass A owns
+    # internal links; Pass B owns web links only.
+    if offline:
+        findings = [f for f in findings if not _is_web(f["url"])]
+    else:
+        findings = [f for f in findings if _is_web(f["url"])]
+
     successful = report.get("successful", 0)
     total = report.get("total", 0)
+    excludes = report.get("excludes", 0)
+    hard = sum(1 for f in findings if f["verdict"] == HARD_FAIL)
+    print(
+        f"{label}: {successful}/{total} OK, {hard} broken, "
+        f"{len(findings) - hard} tolerated, {excludes} excluded"
+    )
+    return findings
 
-    if filtered_count:
-        print(f"ℹ️  Filtered {filtered_count} HTTP/2 false positive(s) from {', '.join(HTTP2_FALSE_POSITIVE_DOMAINS)}")
 
-    if genuine_errors:
-        print(f"\n❌ {total_errors} genuine error(s) found:\n")
-        for filepath, entries in genuine_errors.items():
-            print(f"  {filepath}")
-            for entry in entries:
-                url = entry.get("url", "")
-                status = entry.get("status", {})
-                details = status.get("details", "") or status.get("text", "")
-                line = entry.get("span", {}).get("line", "?")
-                print(f"    [{line}] {url} — {details}")
-        sys.exit(1)
+def main() -> int:
+    argv = sys.argv[1:]
+
+    offline_only = "--offline-only" in argv
+    argv = [a for a in argv if a != "--offline-only"]
+
+    blame_ref = None
+    if "--blame-changed" in argv:
+        i = argv.index("--blame-changed")
+        if i + 1 >= len(argv):
+            print("ERROR: --blame-changed requires a git ref", file=sys.stderr)
+            return EXIT_CANNOT_RUN
+        blame_ref = argv[i + 1]
+        del argv[i : i + 2]
+
+    paths = argv or ["docs/"]
+
+    try:
+        internal = run_pass("internal (offline)", paths, offline=True)
+        external = [] if offline_only else run_pass("external", paths, offline=False)
+    except CannotRun as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return EXIT_CANNOT_RUN
+
+    # Internal links are ours to get right, so a failure blocks no matter which
+    # files the branch touched.
+    blocking = [f for f in internal if f["verdict"] == HARD_FAIL]
+    tolerated = [f for f in internal + external if f["verdict"] == TOLERATED]
+    external_broken = [f for f in external if f["verdict"] == HARD_FAIL]
+
+    unblamed = []
+    if blame_ref is None:
+        blocking += external_broken
     else:
-        print(f"✅ {successful}/{total} links OK ({excludes} excluded)")
-        sys.exit(0)
+        touched = changed_files(blame_ref)
+        if touched is None:
+            blocking += external_broken
+        else:
+            for f in external_broken:
+                if _relative(f["file"]) in touched:
+                    blocking.append(f)
+                else:
+                    unblamed.append(f)
+
+    _print_tolerated(tolerated)
+
+    if unblamed:
+        _print_group(
+            f"⚠️  {len(unblamed)} pre-existing broken link(s) in files this branch "
+            "did not modify — not blocking, but they need fixing:",
+            unblamed,
+        )
+
+    if blocking:
+        _print_group(f"❌ {len(blocking)} broken link(s):", blocking)
+        return EXIT_FAILURES
+
+    if unblamed:
+        print("\n✅ nothing broken in the files this branch modified")
+    else:
+        print("\n✅ no broken links")
+    return EXIT_OK
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/scripts/link-false-positives.toml
+++ b/scripts/link-false-positives.toml
@@ -1,9 +1,0 @@
-# Vendor domains that terminate HTTP/2 connections at the protocol level.
-# These are valid URLs — lychee reports a spurious "HTTP/2 protocol error" for them.
-# Any OTHER error type from these domains (404, DNS failure, etc.) is still reported.
-# Add a domain substring here to suppress the false positive without touching Python.
-
-[http2_false_positives]
-domains = [
-    "sigmaaldrich.com",
-]

--- a/scripts/tests/test_check_links.py
+++ b/scripts/tests/test_check_links.py
@@ -1,0 +1,379 @@
+"""Tests for scripts/check-links.py — the link-failure classifier.
+
+These lock down the behavior that issues #193 and #199 were about: a failure is
+judged by what it says about the *link*, never by which vendor served it. Before
+this classifier the wrapper matched a hand-maintained domain list against the
+literal string "HTTP/2 protocol error", so every newly crawler-hostile vendor
+turned the PR gate red until someone landed a config change.
+
+The JSON fixtures below are real shapes captured from lychee 0.24.2, including
+the two that are easy to get wrong:
+
+  * A mistyped hostname and a vendor resetting the connection produce the
+    *identical* code-less "Connection failed" status. Only a DNS lookup
+    separates them, which is why host_resolves exists.
+  * When a URL repeats across files, lychee reports the repeats from its in-run
+    cache with the status detail stripped ("Error (cached)"). Those entries carry
+    no evidence of their own and must inherit the URL's established verdict.
+
+Every test runs offline: socket.getaddrinfo is monkeypatched, and _run_lychee is
+stubbed for the end-to-end exit-code tests.
+"""
+
+import importlib.util
+import socket
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent.parent / "check-links.py"
+
+
+def _load_module():
+    # The script is hyphenated, so it cannot be imported by name.
+    spec = importlib.util.spec_from_file_location("check_links", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+cl = _load_module()
+
+
+# Hosts the fake resolver knows about. Anything else raises gaierror, standing
+# in for NXDOMAIN.
+RESOLVABLE = {
+    "www.cytivalifesciences.com",
+    "www.sigmaaldrich.com",
+    "www.sonicator.com",
+    "github.com",
+    "doi.org",
+}
+
+
+@pytest.fixture(autouse=True)
+def fake_dns(monkeypatch):
+    """Resolve only known hosts, and never touch the network."""
+
+    def getaddrinfo(host, *args, **kwargs):
+        if host in RESOLVABLE:
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (host, 0))]
+        raise socket.gaierror(socket.EAI_NONAME, "Name or service not known")
+
+    monkeypatch.setattr(socket, "getaddrinfo", getaddrinfo)
+    cl.host_resolves.cache_clear()
+    yield
+    cl.host_resolves.cache_clear()
+
+
+# --- fixture builders -------------------------------------------------------
+
+
+def entry(url, status, line=1):
+    return {"url": url, "status": status, "span": {"line": line, "column": 1}}
+
+
+def coded(url, code, line=1):
+    return entry(url, {"text": f"Rejected status code: {code}", "code": code}, line)
+
+
+def network(url, detail, line=1):
+    return entry(
+        url,
+        {"text": f"Network error: {detail} (error sending request)", "details": detail},
+        line,
+    )
+
+
+def cached(url, line=1):
+    """lychee's detail-stripped repeat of a URL seen earlier in the same run."""
+    return entry(url, {"text": "Error (cached)"}, line)
+
+
+H2_DETAIL = "HTTP/2 protocol error. Server may not support HTTP/2 properly"
+CONN_DETAIL = "Connection failed. Check network connectivity and firewall settings"
+
+CYTIVA = "https://www.cytivalifesciences.com/en/us/products/items/hitrap-butyl-hp-p-05631"
+DEAD_PAGE = "https://github.com/nucleus-eng/nucleus-docs/definitely-not-a-real-page"
+TYPO_HOST = "https://www.sigmaaldrichh.com/US/en/product/sial/a2939"
+
+
+def report(error_map=None, timeout_map=None, **totals):
+    base = {
+        "total": 0,
+        "successful": 0,
+        "errors": 0,
+        "excludes": 0,
+        "error_map": error_map or {},
+        "timeout_map": timeout_map or {},
+    }
+    base.update(totals)
+    return base
+
+
+def verdicts(rep):
+    """URL -> verdict, for a report with one entry per URL."""
+    return {f["url"]: f["verdict"] for f in cl.collect_findings(rep)}
+
+
+# --- classification: the link is wrong -------------------------------------
+
+
+@pytest.mark.parametrize("code", [404, 410])
+def test_gone_status_is_a_hard_failure(code):
+    """404/410 is the one signal that reliably means the link itself is wrong."""
+    v = verdicts(report({"a.md": [coded(DEAD_PAGE, code)]}))
+    assert v[DEAD_PAGE] == cl.HARD_FAIL
+
+
+def test_unresolvable_host_is_a_hard_failure():
+    """A mistyped domain is the most common real authoring error.
+
+    It arrives as a code-less "Connection failed", identical to vendor noise, so
+    tolerating all network errors would silently swallow it.
+    """
+    v = verdicts(report({"a.md": [network(TYPO_HOST, CONN_DETAIL)]}))
+    assert v[TYPO_HOST] == cl.HARD_FAIL
+
+
+def test_missing_local_file_is_a_hard_failure():
+    """A broken relative link is what 404s the deployed site."""
+    url = "file:///repo/docs/modules/modules-main.html"
+    v = verdicts(report({"a.md": [network(url, "Cannot find file")]}))
+    assert v[url] == cl.HARD_FAIL
+
+
+def test_url_with_no_host_is_a_hard_failure():
+    v = verdicts(report({"a.md": [network("https://", CONN_DETAIL)]}))
+    assert v["https://"] == cl.HARD_FAIL
+
+
+# --- classification: tolerated noise ---------------------------------------
+
+
+def test_http2_reset_on_a_live_host_is_tolerated():
+    """Issue #199: Cytiva behaves exactly like Sigma, with no config entry."""
+    v = verdicts(report({"a.md": [network(CYTIVA, H2_DETAIL)]}))
+    assert v[CYTIVA] == cl.TOLERATED
+
+
+def test_no_domain_allowlist_exists():
+    """The fix is structural: nothing in the script names a vendor.
+
+    If a domain list creeps back in, #193/#199 recur for the next vendor.
+    """
+    source = SCRIPT.read_text()
+    for vendor in ("sigmaaldrich", "cytivalifesciences", "sonicator"):
+        assert vendor not in source.lower().replace("#193", "").replace("#199", "")
+
+
+@pytest.mark.parametrize("code", [401, 403, 429, 500, 502, 503, 504])
+def test_refused_and_hiccup_statuses_are_tolerated(code):
+    """Issue #193: a 503 says the server had a bad moment, not that we are wrong."""
+    url = "https://www.sonicator.com/products/q700-sonicator"
+    v = verdicts(report({"a.md": [coded(url, code)]}))
+    assert v[url] == cl.TOLERATED
+
+
+@pytest.mark.parametrize("code", [400, 405, 406, 451])
+def test_other_4xx_are_tolerated(code):
+    """Bot-shaped rejections. Only 404/410 speak to the link's validity."""
+    url = "https://doi.org/10.1126/science.274.5294.1859"
+    v = verdicts(report({"a.md": [coded(url, code)]}))
+    assert v[url] == cl.TOLERATED
+
+
+def test_403_is_reported_not_silently_accepted():
+    """403 used to sit in .lychee.toml's accept list, making it invisible.
+
+    It is still non-blocking, but it must now show up as a finding so a vendor
+    quietly refusing every request is at least visible.
+    """
+    url = "https://doi.org/10.1126/science.274.5294.1859"
+    findings = cl.collect_findings(report({"a.md": [coded(url, 403)]}))
+    assert len(findings) == 1
+    assert findings[0]["verdict"] == cl.TOLERATED
+    assert "403" in findings[0]["reason"]
+
+
+def test_timeouts_are_reported_and_tolerated():
+    """Regression test: timeouts live in timeout_map, absent from error_map.
+
+    The previous wrapper read only error_map, so every timeout vanished without
+    a word while the summary line still claimed success.
+    """
+    url = "https://www.sonicator.com/products/q700-sonicator"
+    findings = cl.collect_findings(
+        report(timeout_map={"a.md": [entry(url, {"text": "Timeout"})]})
+    )
+    assert len(findings) == 1
+    assert findings[0]["verdict"] == cl.TOLERATED
+
+
+# --- cached repeats inherit their URL's verdict -----------------------------
+
+
+def test_cached_repeat_of_tolerated_url_is_tolerated():
+    rep = report(
+        {
+            "a.md": [network(CYTIVA, H2_DETAIL)],
+            "b.md": [cached(CYTIVA)],
+        }
+    )
+    findings = cl.collect_findings(rep)
+    assert len(findings) == 2
+    assert {f["verdict"] for f in findings} == {cl.TOLERATED}
+
+
+def test_cached_repeat_of_dead_url_still_fails():
+    """The dangerous direction: a stripped repeat must not launder a 404."""
+    rep = report(
+        {
+            "a.md": [coded(DEAD_PAGE, 404)],
+            "b.md": [cached(DEAD_PAGE)],
+        }
+    )
+    findings = cl.collect_findings(rep)
+    assert len(findings) == 2
+    assert {f["verdict"] for f in findings} == {cl.HARD_FAIL}
+
+
+def test_cached_repeat_seen_before_its_source_still_inherits():
+    """Order must not matter — lychee does not guarantee file ordering."""
+    rep = report(
+        {
+            "a.md": [cached(DEAD_PAGE)],
+            "b.md": [coded(DEAD_PAGE, 404)],
+        }
+    )
+    assert {f["verdict"] for f in cl.collect_findings(rep)} == {cl.HARD_FAIL}
+
+
+def test_orphan_cached_entry_defaults_to_tolerated():
+    """With no evidence anywhere for the URL, do not invent a failure."""
+    rep = report({"a.md": [cached(CYTIVA)]})
+    assert verdicts(rep)[CYTIVA] == cl.TOLERATED
+
+
+# --- end-to-end exit codes -------------------------------------------------
+
+
+@pytest.fixture
+def stub_lychee(monkeypatch):
+    """Stub _run_lychee, returning a different report per pass."""
+
+    def install(internal=None, external=None):
+        def fake(args, offline):
+            return (internal if offline else external) or report()
+
+        monkeypatch.setattr(cl, "_run_lychee", fake)
+
+    return install
+
+
+def test_clean_run_exits_zero(stub_lychee, capsys):
+    stub_lychee()
+    assert cl.main() == cl.EXIT_OK
+    assert "no broken links" in capsys.readouterr().out
+
+
+def test_tolerated_only_run_exits_zero(stub_lychee, capsys):
+    """The whole point: 87 vendor failures must not fail the build."""
+    stub_lychee(external=report({"a.md": [network(CYTIVA, H2_DETAIL)]}))
+    assert cl.main() == cl.EXIT_OK
+    out = capsys.readouterr().out
+    assert "tolerated" in out
+    assert "no broken links" in out
+
+
+def test_dead_link_exits_one(stub_lychee):
+    stub_lychee(external=report({"a.md": [coded(DEAD_PAGE, 404)]}))
+    assert cl.main() == cl.EXIT_FAILURES
+
+
+def test_broken_internal_link_exits_one(stub_lychee):
+    """Internal links block unconditionally — they break the deployed site."""
+    url = "file:///repo/docs/modules/gone.md"
+    stub_lychee(internal=report({"a.md": [network(url, "Cannot find file")]}))
+    assert cl.main() == cl.EXIT_FAILURES
+
+
+def test_offline_only_skips_the_network_pass(stub_lychee, monkeypatch):
+    """--offline-only must not fetch anything, even if externals would fail."""
+    calls = []
+
+    def fake(args, offline):
+        calls.append(offline)
+        return report({"a.md": [coded(DEAD_PAGE, 404)]}) if not offline else report()
+
+    monkeypatch.setattr(cl, "_run_lychee", fake)
+    monkeypatch.setattr("sys.argv", ["check-links.py", "--offline-only", "docs/"])
+    assert cl.main() == cl.EXIT_OK
+    assert calls == [True]
+
+
+def test_unparseable_output_exits_two(monkeypatch):
+    """Tooling breakage must be distinguishable from a link failure.
+
+    Both used to exit 1, so a broken lychee install read as broken docs.
+    """
+
+    def boom(args, offline):
+        raise cl.CannotRun("lychee is not installed")
+
+    monkeypatch.setattr(cl, "_run_lychee", boom)
+    assert cl.main() == cl.EXIT_CANNOT_RUN
+
+
+def test_blame_changed_requires_a_ref(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["check-links.py", "--blame-changed"])
+    assert cl.main() == cl.EXIT_CANNOT_RUN
+
+
+# --- blame partitioning ----------------------------------------------------
+
+
+def test_rot_in_an_untouched_file_does_not_block(stub_lychee, monkeypatch, capsys):
+    stub_lychee(external=report({"docs/old.md": [coded(DEAD_PAGE, 404)]}))
+    monkeypatch.setattr(cl, "changed_files", lambda ref: {"docs/mine.md"})
+    monkeypatch.setattr(
+        "sys.argv", ["check-links.py", "--blame-changed", "origin/main", "docs/"]
+    )
+    assert cl.main() == cl.EXIT_OK
+    out = capsys.readouterr().out
+    assert "pre-existing" in out
+    assert DEAD_PAGE in out  # still reported, just not blocking
+
+
+def test_rot_in_a_touched_file_blocks(stub_lychee, monkeypatch):
+    stub_lychee(external=report({"docs/mine.md": [coded(DEAD_PAGE, 404)]}))
+    monkeypatch.setattr(cl, "changed_files", lambda ref: {"docs/mine.md"})
+    monkeypatch.setattr(
+        "sys.argv", ["check-links.py", "--blame-changed", "origin/main", "docs/"]
+    )
+    assert cl.main() == cl.EXIT_FAILURES
+
+
+def test_internal_failure_blocks_even_when_unblamed(stub_lychee, monkeypatch):
+    """Blame partitioning applies to external rot only.
+
+    A broken relative link in an untouched file still breaks the built site, so
+    it must block regardless.
+    """
+    url = "file:///repo/docs/modules/gone.md"
+    stub_lychee(internal=report({"docs/old.md": [network(url, "Cannot find file")]}))
+    monkeypatch.setattr(cl, "changed_files", lambda ref: {"docs/mine.md"})
+    monkeypatch.setattr(
+        "sys.argv", ["check-links.py", "--blame-changed", "origin/main", "docs/"]
+    )
+    assert cl.main() == cl.EXIT_FAILURES
+
+
+def test_undiffable_ref_falls_back_to_blocking_everything(stub_lychee, monkeypatch):
+    """If git cannot answer, fail closed rather than silently passing rot."""
+    stub_lychee(external=report({"docs/old.md": [coded(DEAD_PAGE, 404)]}))
+    monkeypatch.setattr(cl, "changed_files", lambda ref: None)
+    monkeypatch.setattr(
+        "sys.argv", ["check-links.py", "--blame-changed", "origin/main", "docs/"]
+    )
+    assert cl.main() == cl.EXIT_FAILURES

--- a/setup.sh
+++ b/setup.sh
@@ -24,7 +24,13 @@ else
   echo "WARNING: npm not found. Install Node.js then run: npm install -g mystmd@1.9.1"
 fi
 
-# Install lychee if not already present
+# Install lychee if not already present.
+# CI pins lychee to the version below (see .github/workflows/check-links.yml and
+# link-rot.yml) because its JSON report is the input contract for
+# scripts/check-links.py and has changed shape between releases. brew installs
+# whatever is current, so a local run can classify differently than CI — if the
+# versions drift far apart, bump the workflows to match.
+LYCHEE_PINNED_VERSION="0.24.2"
 if ! command -v lychee &> /dev/null; then
   if command -v brew &> /dev/null; then
     brew install lychee
@@ -32,6 +38,14 @@ if ! command -v lychee &> /dev/null; then
     echo "WARNING: lychee not found and brew is not available."
     echo "  Install lychee manually: https://github.com/lycheeverse/lychee#installation"
     echo "  The check-links script will fail until lychee is on your PATH."
+  fi
+fi
+
+if command -v lychee &> /dev/null; then
+  installed=$(lychee --version | awk '{print $2}')
+  if [ "$installed" != "$LYCHEE_PINNED_VERSION" ]; then
+    echo "NOTE: local lychee is $installed but CI pins $LYCHEE_PINNED_VERSION."
+    echo "  Link-check results may differ from CI. See .github/workflows/check-links.yml."
   fi
 fi
 


### PR DESCRIPTION
Closes #193. Closes #199.

## The problem

A full-corpus run finds **87 errors and not one carries an HTTP status code** — every single failure is a vendor resetting the connection or refusing a crawler. Of the last 25 `check-links` runs, 16 failed and **none found a real broken link**; the 8 most recent are all the same three `cytivalifesciences.com` URLs, red on every PR for a week.

The cause was the classification axis. The wrapper matched a hand-maintained domain list against the literal string `HTTP/2 protocol error`, so each newly crawler-hostile vendor turned the gate red until someone landed a config change. #199 fails only because Cytiva isn't in that list — it behaves identically to Sigma, which is.

Two corrections to the issues' own diagnoses:

- **#193's suggested fix was already the default.** lychee ships `--max-retries 3`; sonicator's 503s already survive three attempts. What was never configured is *concurrency* — lychee fires 10 parallel requests per host by default, so a vendor with a dozen catalog links in one BOM gets a burst big enough to provoke the 503. We were likely causing it.
- **#199's option 3 is impossible.** lychee 0.24.2 has no HTTP/1.1 flag, so per-domain protocol downgrade isn't available.

## The fix

Judge a failure by what it says about the **link**, not by who served it. lychee's JSON already separates these — status errors carry a `code`, transport errors don't — so no domain list and no error-string matching is needed.

| Signal | Verdict |
| --- | --- |
| HTTP 404 / 410 | **blocking** — resource is gone |
| Hostname does not resolve | **blocking** — typo'd or dead domain |
| Relative link resolves to no file | **blocking** — 404s the deployed site |
| 401, 403, 429, any 5xx, other 4xx | tolerated, reported |
| Timeout, TLS error, HTTP/2 reset | tolerated, reported |

**The one trap:** a mistyped hostname and a vendor connection reset produce the *identical* code-less `Connection failed` status. Tolerating all network errors would silently swallow the most common real authoring mistake, so a DNS lookup settles it. That's the load-bearing part of the design.

## Structural changes

- **Two passes.** Offline internal-link pass over the whole corpus (~50 ms, always blocking — a broken relative link breaks the built site), then a network pass over external URLs.
- **`--blame-changed`.** Coverage stays whole-corpus — this is a staleness check — but only rot in files the PR *modified* blocks it. Pre-existing rot is reported without blocking a PR that didn't cause it.
- **New weekly `link-rot.yml`** runs unpartitioned against `main` and keeps a single tracking issue up to date. Issue filing belongs on a schedule, not in a PR run where fork tokens are read-only and re-runs would duplicate.
- **`timeout_map` is now read.** The old wrapper ignored it entirely, so every timeout vanished without a word while the summary still claimed success.
- **403 removed from `accept`.** It's still non-blocking but now *visible* — this surfaces 36 previously invisible 403s (17 on `doi.org` alone).
- **`host_concurrency = 4`** plus a 200 ms interval, to stop provoking #193.
- **Exit 2 when the check can't run**, so a broken toolchain no longer reads as broken docs.
- **lychee pinned to 0.24.2.** Its JSON is this script's input contract and has changed shape between releases (#136); tracking `latest` meant CI could classify differently than any local run.
- **`scripts/link-false-positives.toml` deleted.**

## Tests

`scripts/tests/test_check_links.py` — 35 tests over real captured lychee JSON with DNS monkeypatched, all offline. This script previously had **no coverage at all**, which is how the drift went unnoticed. Includes the two cases that are easy to get wrong: a stripped `Error (cached)` repeat must not launder a 404, and must not invent a failure when it's the only evidence. Picked up by the existing `bom-tests` job.

One test asserts no vendor name appears in the script at all — if a domain list creeps back, these issues recur for the next vendor.

## Verification

- `pytest scripts/tests/ -q` → **50 passed** (35 new + 15 existing)
- `check-links.py --offline-only docs/` → 104 internal links, 0 broken, 0.05 s
- `check-links.py docs/` → **exit 0** in 16 s, 0 broken, 123 tolerated
- Negative controls: a 404 URL, a typo'd hostname, and an `.html` internal link each produce a blocking failure with the correct file and line
- Blame partitioning verified both directions

## Honest limits, now documented

Staleness detection only works where a vendor returns an honest status code. **Sigma and Cytiva never do** (~40% of external links), so a discontinued part number there is undetectable at any frequency, and soft-404s (HTTP 200 on a "product not found" page) are invisible everywhere. Both still need manual review. CLAUDE.md and the `lint-docs` skill now say so rather than implying broader coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)