### PR TITLE
Fill in ClpXP Designs table (DNA constructs migrated)

### DIFF
--- a/docs/modules/control-clpxp/spec.md
+++ b/docs/modules/control-clpxp/spec.md
@@ -22,9 +22,9 @@ Cartoon of the general mechanism of protein degradation by ClpXP, an ATP-depende
 ::::{tab-item} Designs
 | **Name** | **Length (bp)** | **File** |
 | --- | --- | --- |
-| `pT7-ClpX` | N/A | (upcoming) |
-| `pT7-ClpP` | N/A | (upcoming) |
-| `pT7-deGFP-ssrA` | N/A | (upcoming) |
+| `pT7-ClpX` | 3394 | [pOpen-ClpX-CHis.gb](https://github.com/nucleus-eng/DNA/blob/main/control/pOpen-ClpX-CHis.gb) |
+| `pT7-ClpP` | 2746 | [pOpen-ClpP-CHis.gb](https://github.com/nucleus-eng/DNA/blob/main/control/pOpen-ClpP-CHis.gb) |
+| `pT7-deGFP-ssrA` | 2863 | [pOpen-deGFP-CHis-ssrA.gb](https://github.com/nucleus-eng/DNA/blob/main/control/pOpen-deGFP-CHis-ssrA.gb) |
 ::::
 
 :::::


### PR DESCRIPTION
## Summary
- Fills in the `pT7-ClpX` / `pT7-ClpP` / `pT7-deGFP-ssrA` placeholder rows in `docs/modules/control-clpxp/spec.md`'s Designs table — these were "(upcoming)" pending nucleus-eng/DNA#3.
- Constructs landed in nucleus-eng/DNA#8 under a new `control/` directory, as CHis-tagged variants (no untagged versions exist in the source material). Author confirmed the CHis-tagged `deGFP-ssrA` is the correct match for the bare `pT7-deGFP-ssrA` docs name.
- Closes #51.

## Test plan
- [ ] Confirm bp counts (3394 / 2746 / 2863) match `LOCUS` lines in the linked files.
- [ ] Confirm build/myst renders the table correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)