### PR TITLE
fix: link Documentation card to its section anchor

### DIFF
--- a/intro.md
+++ b/intro.md
@@ -20,7 +20,7 @@ The Nucleus platform makes it possible to access tools and workflows, contribute
 
 :::{card}
 :header: 📖 **Documentation**
-:link: https://docs.nucleus.engineering
+:link: #documentation
 
 Lab protocols, module specifications, and implementation guides for the Nucleus Distribution.
 :::


### PR DESCRIPTION
## Summary
- The Documentation card in the Platform grid on the homepage linked to `https://docs.nucleus.engineering`, which is the same page — clicking it just reloaded the top of the page instead of jumping to the "Documentation" header further down.
- Changed the card's link to the section anchor (`#documentation`) so it scrolls to that header.

Fixes #218

## Test plan
- [x] `vale intro.md` — 0 errors
- [x] `codespell intro.md` — clean
- [x] `python3 scripts/check-links.py --offline-only intro.md` — no broken links
- [ ] Visual check on the deployed preview that the card scrolls to the Documentation header (myst is not installed locally, so this wasn't verified by a local build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)