### PR TITLE
Generate the module-integration-map from a pipeline instead of hand-authoring it

### DIFF
--- a/.claude/skills/mermaid-diagrams/PROVENANCE.md
+++ b/.claude/skills/mermaid-diagrams/PROVENANCE.md
@@ -1,0 +1,16 @@
+# Provenance
+
+Vendored from `nucleus-eng/nucleus-skills`, PR #6 ("Add mermaid-diagrams
+skill"), commit `d265d95acf7c9e2a0611fe63a2bb71674b22c1d7` on branch
+`feat/mermaid-diagrams-skill`. Captured 2026-08-24.
+
+PR #6 is not merged as of this capture. This is a snapshot, not a live
+dependency — when the PR merges (and `.claude/settings.json` in this repo
+picks up the `nucleus@nucleus` marketplace plugin), this local copy should
+be deleted rather than kept in sync by hand. Until then, `scripts/
+generate-module-graph.py` and `scripts/render-module-graph.py` in this
+repo call the scripts here directly.
+
+Do not edit the files under `references/` or `scripts/` in this directory
+— upstream fixes belong on the PR, not here. `SKILL.md` is unmodified from
+the PR.

--- a/.claude/skills/mermaid-diagrams/SKILL.md
+++ b/.claude/skills/mermaid-diagrams/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: mermaid-diagrams
+description: Write Mermaid diagram source for Nucleus documentation — module dependency graphs, process dependency graphs, and combined implementation views. Use when asked to draw, add, regenerate, or fix a diagram, flowchart, schematic, or dependency graph on a docs page; when a page needs a composition or integration diagram; or when a diagram's status markings need updating. Covers fence form, node-id safety, status conventions, greyscale-by-default styling, and deriving a diagram from a page's own Composition sections. Source only — this skill does not render to PNG or SVG.
+---
+
+# Mermaid diagrams for Nucleus docs
+
+Write the source. Do not render it.
+
+Rendering (`.mmd` → PNG/SVG for slides) is a separate concern with separate
+tooling and is deliberately out of scope here. Everything below produces text
+that goes into a Markdown page.
+
+## Two hard rules, both learned the painful way
+
+### 1. Fence form depends on the renderer
+
+| Fence | MyST site | Obsidian |
+| --- | --- | --- |
+| ` ```mermaid ` | renders | **renders** |
+| ` ```{mermaid} ` | renders | **blank** |
+
+Obsidian only understands the plain fence. MyST understands both. **Default to
+the plain fence** — one form that works everywhere — unless the repo you are
+editing has already standardised on the directive form, in which case match it
+and say so.
+
+Check before writing:
+
+```bash
+grep -rc '^```mermaid$'    docs/ --include='*.md' | awk -F: '{s+=$2} END {print "plain:     "s}'
+grep -rc '^```{mermaid}'   docs/ --include='*.md' | awk -F: '{s+=$2} END {print "directive: "s}'
+```
+
+If a repo is split across both forms, raise it — mixed fences mean some diagrams
+are invisible in one of the two tools, and nobody notices until someone opens the
+wrong one.
+
+### 2. Node ids must be identifier-safe, and must never come from prose
+
+A Mermaid node id cannot contain spaces. Derive ids mechanically:
+
+```python
+def node_id(slug):
+    return re.sub(r"[^A-Za-z0-9]", "_", slug).upper()
+```
+
+**Why this is a rule and not a preference.** A terminology sweep once replaced a
+word across a docs tree. That word was a node id in two diagrams, and the
+replacement contained a space:
+
+```
+    composed thing["A Composed Thing"]     <-- broken: id has a space
+    INPUT --> composed thing               <-- broken: same
+```
+
+Both diagrams silently stopped rendering. So: ids are `UPPER_SNAKE`, labels are
+prose inside quotes, and the two never share a string. After **any** text sweep
+over a directory containing diagrams, check for the damage:
+
+```bash
+grep -rnE '^\s+[a-z]+ [a-z]+\[|--> [a-z]+ [a-z]+$|,[a-z]+ [a-z]+ ' docs/ --include='*.md'
+```
+
+## Greyscale unless colour is asked for
+
+Default to greyscale. Colour should carry meaning, and most diagrams have no
+meaningful distinction to encode — a diagram that is colourful for decoration
+teaches the reader nothing and costs contrast.
+
+```
+    classDef leaf     fill:#e5e7eb,stroke:#6b7280,color:#111827;
+    classDef composed fill:#6b7280,stroke:#374151,color:#ffffff;
+```
+
+Two shades is usually enough: lighter for inputs and leaves, darker for things
+built out of other things.
+
+**When the user does ask for colour**, use a colourblind-safe palette and use it
+to encode one real distinction. See `references/palettes.md`.
+
+## Three diagram types, and keep them separate
+
+The single most common mistake is mixing kinds of thing in one diagram.
+
+### Module dependency graph — modules only
+
+What a module is composed of. Every node is a module; every edge is "is a
+constituent of". No processes, no analytes, no equipment.
+
+```mermaid
+flowchart TD
+    BASE_INPUT_A["Input Module A"]
+    BASE_INPUT_B["Input Module B"]
+    COMPOSED["Composed Module"]
+
+    BASE_INPUT_A --> COMPOSED
+    BASE_INPUT_B --> COMPOSED
+
+    classDef leaf     fill:#e5e7eb,stroke:#6b7280,color:#111827;
+    classDef composed fill:#6b7280,stroke:#374151,color:#ffffff;
+    class BASE_INPUT_A,BASE_INPUT_B leaf;
+    class COMPOSED composed;
+
+    click BASE_INPUT_A "/docs/modules/input-a/spec"
+    click COMPOSED "/docs/modules/composed/spec"
+```
+
+Arrows point **from constituent to container** — "this feeds into that."
+
+### Process dependency graph — processes only
+
+Which protocol has to happen before which. Every node is a process page.
+
+```mermaid
+flowchart TD
+    PREP["Prepare Inputs"]
+    ASSEMBLE["Assemble"]
+    READOUT["Read Out"]
+
+    PREP --> ASSEMBLE
+    ASSEMBLE --> READOUT
+```
+
+### Combined implementation view — modules and processes together
+
+Only here do the two mix, and they must be visually distinguishable. Modules are
+**boxes**, processes are **stadiums** `([...])`:
+
+```mermaid
+flowchart LR
+    MOD_A["Module A"]
+    MOD_B["Module B"]
+    PROC(["Assembly Process"])
+    RESULT["Assembled Module"]
+
+    MOD_A --> PROC
+    MOD_B --> PROC
+    PROC --> RESULT
+```
+
+Do not use diamonds for processes — a diamond reads as a decision point and will
+mislead. Reserve diamonds for genuine branch points, such as an undecided design
+choice.
+
+## Status conventions
+
+Three edge styles, three genuinely different claims. Do not collapse them.
+
+| Style | Meaning |
+| --- | --- |
+| `A --> B` | confirmed — this has been demonstrated |
+| `A -.-> B` | proposed — believed to work, not yet attempted |
+| `A --x B` | blocked — the parts work, this specific integration does not |
+
+`-.->` and `--x` are not synonyms. "Nobody has tried it" and "we tried and it is
+prevented" are different states, and conflating them loses the only information
+a reader wanted.
+
+**Node borders.** A node gets a dashed border if **any** incoming edge is
+dashed. Propagate downstream from edge targets:
+
+```
+    style DOWNSTREAM_NODE stroke-dasharray: 5 5
+```
+
+**Evidence proportional to claim.** `--x` asserts that something does not work.
+That is the strongest claim available and needs the strongest evidence. Before
+drawing one, confirm there is a documented result behind it, not an inference. A
+`--x` supported only by a verbal report should be `-.->` with the concern in
+prose.
+
+**Legends are standalone.** Render a legend as its own small diagram, never as a
+subgraph inside the main one — a subgraph wrapper adds a background tint and
+visually implies grouping that is not there.
+
+## Derive the diagram from the page, do not hand-maintain it
+
+A hand-drawn dependency diagram drifts from the pages within weeks. If the
+composition is already written in the docs, generate the diagram from it.
+
+Most Nucleus module pages carry a `# Constituent Modules` section. That is a
+machine-readable dependency graph:
+
+```python
+m = re.search(r"^#+\s*Constituent Modules\s*$(.*?)(?=^#|\Z)", text, re.M | re.S)
+for link in re.finditer(r"\]\(\.\./([A-Za-z0-9._-]+)/spec\.md", m.group(1)):
+    ...
+```
+
+Wrap generated output in markers so regeneration is idempotent and hand-written
+content is never clobbered:
+
+```markdown
+<!-- gen:composition-diagram -->
+```mermaid
+...
+```
+<!-- /gen:composition-diagram -->
+```
+
+See `references/deriving.md` for the full pattern, including a `--check` mode
+suitable for CI.
+
+**A generated diagram must not assert status.** Composition is derivable from the
+pages. Whether an integration is *confirmed* is not — that lives in status
+documents on a different axis entirely. A generated diagram that draws solid
+edges is claiming something it never checked. Either draw all edges plain and
+caption the diagram as composition-only, or read status from an explicit field.
+
+**Link presence is not dependency.** Pages legitimately link to modules they do
+not depend on — to explain an absence, or to contrast against something else.
+Scraping every link produces phantom nodes. Take the dependency set from a
+declared section, or from an explicit list, and never from "every link on the
+page."
+
+## Embedding in a page
+
+Diagrams usually belong in a tab-set alongside other visual material. Nucleus
+tab-sets use a strict three-level fence depth:
+
+````markdown
+:::::{tab-set}
+
+::::{tab-item} Mechanism
+
+```mermaid
+flowchart LR
+    A["Thing"] --> B["Other Thing"]
+```
+
+Caption explaining what the diagram shows, and what it does not.
+
+::::
+
+::::{tab-item} Dependencies
+
+```mermaid
+flowchart TD
+    X["Constituent"] --> Y["This Module"]
+```
+
+::::
+
+:::::
+````
+
+Five colons for `{tab-set}`, four for each `{tab-item}`, three for anything
+nested inside. Mismatched counts are the most common cause of a tab-set failing
+to render.
+
+`click` directives use **absolute** paths (`/docs/modules/<name>/spec`), not
+relative ones — relative click targets break on the deployed site.
+
+## Checklist before you finish
+
+- [ ] Fence form matches the target repo, or the plain form if starting fresh
+- [ ] Every node id is `UPPER_SNAKE`, no spaces
+- [ ] Greyscale, unless colour was requested and encodes something
+- [ ] One kind of thing per diagram, or shapes distinguish the kinds
+- [ ] Edge styles match the actual evidence; no `--x` on a verbal report
+- [ ] Dashed borders propagated to downstream nodes
+- [ ] `click` targets are absolute paths
+- [ ] Tab-set fence depths are 5 / 4 / 3
+- [ ] Caption says what the diagram does **not** claim
+- [ ] If generated: wrapped in markers, and re-running produces no diff

--- a/.claude/skills/mermaid-diagrams/references/deriving.md
+++ b/.claude/skills/mermaid-diagrams/references/deriving.md
@@ -1,0 +1,151 @@
+# Deriving diagrams from page structure
+
+Load this when generating diagrams from docs rather than hand-writing them.
+
+A hand-drawn dependency diagram drifts from the pages it describes within weeks,
+and the drift is invisible — the diagram still renders, it is just wrong. If the
+structure is already written down somewhere in the docs, read it from there.
+
+## The graph is usually already in the pages
+
+Nucleus module pages declare their constituents in a section:
+
+```markdown
+# Constituent Modules
+
+- [Input Module A](../input-a/spec.md) — what it contributes
+- [Input Module B](../input-b/spec.md)
+```
+
+That is a dependency edge list. Extract it:
+
+```python
+def constituents(text):
+    m = re.search(r"^#+\s*Constituent Modules\s*$(.*?)(?=^#|\Z)", text, re.M | re.S)
+    if not m:
+        return []
+    out = []
+    for link in re.finditer(r"\]\(\.\./([A-Za-z0-9._-]+)/spec\.md", m.group(1)):
+        slug = link.group(1)
+        if slug not in out:
+            out.append(slug)
+    return out
+```
+
+Restrict to tracked files, so gitignored build artifacts do not enter the graph:
+
+```bash
+git ls-files docs/modules
+```
+
+## Two relations, not one
+
+Composition is not the only edge kind. A module can also *require* something it
+is not made of — a substrate that must be present, an enzyme that must be
+supplied, a condition that must hold.
+
+| Relation | Meaning | Style |
+| --- | --- | --- |
+| composition | "is made of" | `A --> B` solid |
+| requirement | "must be present for this to function" | `A -.->|requires| B` |
+
+Drawing them the same way is what makes a required-but-not-constituent module
+appear as a floating node with no edges. If a node has no edges, check whether it
+is actually a requirement of something before deleting it from the diagram.
+
+Requirements are usually prose, so they need declaring explicitly until pages
+carry a structured field for them:
+
+```python
+REQUIRES = {
+    ("reporter-module", "substrate-module"),
+    ("reporter-module", "effector-module"),
+}
+```
+
+## Idempotent insertion
+
+Wrap generated blocks in markers. Regeneration then replaces only what is
+between them and never touches hand-written content:
+
+````python
+BEGIN = "<!-- gen:composition-diagram -->"
+END   = "<!-- /gen:composition-diagram -->"
+
+m = re.search(re.escape(BEGIN) + r".*?" + re.escape(END), text, re.S)
+if m:
+    text = text[:m.start()] + block + text[m.end():]
+else:
+    # no marker on this page — report it, do not guess a location
+    ...
+````
+
+**Do not auto-place a marker that is not there.** Where a diagram belongs on a
+page is an editorial decision. Report the pages missing markers and let a human
+place them once.
+
+## Three modes worth having
+
+| Mode | Behaviour |
+| --- | --- |
+| default | write proposals to a scratch directory, touch nothing in `docs/` |
+| `--write` | replace content between existing markers |
+| `--check` | exit non-zero if any page's block is stale — suitable for CI |
+
+The default being a dry run matters. A generator that writes on first invocation
+will eventually write something nobody asked for.
+
+## Scope the graph honestly
+
+**Roots must be declared, not inferred from links.** Pages link to modules they
+do not depend on — to explain why something was removed, or to contrast against
+a different implementation. Scraping every link puts phantom nodes in the
+diagram. Take roots from an explicit list.
+
+**Every node should be a dependency of something in the diagram.** A node with no
+path to a root is either a mistake or a signal that the declared roots are wrong.
+Both are worth reporting rather than rendering.
+
+**Exclude proposed constituents.** A page may list an alternative it is not
+currently using. Including it implies a dependency that does not exist:
+
+```python
+EXCLUDE_EDGES = {
+    ("some-cascade", "proposed-alternate-reporter"),
+}
+```
+
+**Subset relationships are checkable, so check them.** If you generate both a
+per-subsystem diagram and a whole-system diagram, assert the former is a subset
+of the latter. When it is not, one of the two is wrong, and the assertion tells
+you which pass introduced it.
+
+## What a generated diagram may and may not claim
+
+It may claim **structure** — what is composed of what — because that is what it
+read.
+
+It may not claim **status**. Whether an integration has been demonstrated lives
+in status documents on a separate axis, and a generator that draws confirmed
+edges is asserting something it never checked.
+
+So either draw every edge plain and caption the diagram as composition-only, or
+read status from an explicit field and cite it. Never infer status from the
+existence of a composition edge — a page can describe a composition that has
+never been assembled.
+
+Put the limit in the caption, not just in the commit message:
+
+> This diagram shows composition only. It does not assert that any integration is
+> confirmed.
+
+## A diagnostic worth knowing
+
+A page that *should* be the root of a subsystem, but comes out excluded from its
+own dependency graph, has wrong constituents. This is a genuinely useful signal:
+one such exclusion revealed a page still listing a component that had been
+dropped from the design weeks earlier, which no amount of proofreading had
+caught.
+
+Generating the diagram found it because the graph made the absence structural
+rather than textual.

--- a/.claude/skills/mermaid-diagrams/references/palettes.md
+++ b/.claude/skills/mermaid-diagrams/references/palettes.md
@@ -1,0 +1,82 @@
+# Palettes
+
+Load this only when the user has explicitly asked for colour. The default is
+greyscale — see the main skill.
+
+## Greyscale (default)
+
+Two shades carry most diagrams:
+
+```
+    classDef leaf     fill:#e5e7eb,stroke:#6b7280,color:#111827;
+    classDef composed fill:#6b7280,stroke:#374151,color:#ffffff;
+```
+
+A third, for the node the page is about:
+
+```
+    classDef this     fill:#374151,stroke:#111827,color:#ffffff;
+```
+
+If you need more than three shades, the diagram is probably encoding something
+that wants a second diagram instead.
+
+## Colourblind-safe categorical palette
+
+Okabe–Ito, which is distinguishable under the common forms of colour vision
+deficiency. Fill, stroke, and text are given together because a light fill with
+default black text fails contrast at small sizes.
+
+| Hue | Fill | Stroke | Text |
+| --- | --- | --- | --- |
+| Blue | `#e3f0f8` | `#0072B2` | `#063a57` |
+| Orange | `#fbe8dc` | `#D55E00` | `#7a2d00` |
+| Green | `#def5ee` | `#009E73` | `#00402e` |
+| Yellow | `#fdf3d9` | `#E69F00` | `#6b4a00` |
+| Purple | `#f2e6f2` | `#CC79A7` | `#5c2a4a` |
+| Neutral | `#f1efe8` | `#5f5e5a` | `#2c2c2a` |
+
+```
+    classDef groupOne fill:#e3f0f8,stroke:#0072B2,color:#063a57;
+    classDef groupTwo fill:#fbe8dc,stroke:#D55E00,color:#7a2d00;
+    classDef shared   fill:#def5ee,stroke:#009E73,color:#00402e;
+```
+
+## Rules for using colour at all
+
+**Colour encodes exactly one distinction.** Pick the dimension — which group owns
+a node, which subsystem it belongs to, confirmed versus proposed — and use hue
+for that alone. Encoding two dimensions in hue produces a diagram nobody can
+read without the legend open beside it.
+
+**Never use hue as the only carrier of a status claim.** Status is already
+carried by edge style and border dash, which survive greyscale printing,
+screenshots, and colourblind viewers. Hue may reinforce it; it may not be the
+sole signal.
+
+**Abstract or generalised diagrams are always uniform grey.** Colour is for
+meaningful distinctions between concrete things. An abstraction has none to show
+— if a schematic is showing the *shape* of a system rather than a specific
+instance, every node is the same shade.
+
+**Match an existing diagram's palette before inventing one.** Two diagrams of the
+same system in different palettes read as two different systems.
+
+## Dark mode
+
+Mermaid's own theming does not follow a site's dark mode reliably, and diagrams
+authored for a light background can render close to unreadable against a dark
+one. There is no clean fix inside Mermaid.
+
+Two workarounds, in order of preference:
+
+1. **Keep the diagram simple enough that the default theme works in both.** Fewer
+   custom `fill` declarations means fewer things to go wrong. A diagram with no
+   `classDef` at all inherits the theme and usually survives.
+2. **For a diagram that genuinely must look right in both**, hand-author an inline
+   SVG with CSS custom properties and a `prefers-color-scheme` block instead of
+   using Mermaid. This costs the source-diffability that makes Mermaid worth
+   using, so reserve it for a small number of high-visibility diagrams.
+
+If you hit this, say so rather than shipping a diagram that is unreadable for
+half the readers.

--- a/.claude/skills/mermaid-diagrams/scripts/gen-module-diagrams.py
+++ b/.claude/skills/mermaid-diagrams/scripts/gen-module-diagrams.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""
+gen-module-diagrams.py — generate a composition diagram for each Module spec.
+
+Implements issue #209: "By tracing the Composition path of a module (i.e., Base
+Cell from composition of Base Cytosol and Base Membrane), we can construct an
+integration requirements diagram for each module."
+
+The graph is read from each page's `# Constituent Modules` section, so the diagram
+is derived from the docs rather than maintained alongside them. Regenerating after
+a composition change is therefore a no-op unless the composition actually changed.
+
+Output is a plain ```mermaid block wrapped in marker comments:
+
+    <!-- gen:composition-diagram -->
+    ```mermaid
+    ...
+    ```
+    <!-- /gen:composition-diagram -->
+
+Rewriting is idempotent: an existing block between the markers is replaced, and
+nothing outside them is touched.
+
+Usage:
+    python3 scripts/gen-module-diagrams.py                 # dry run -> tmp/proposed-diagrams/
+    python3 scripts/gen-module-diagrams.py --write         # insert into pages
+    python3 scripts/gen-module-diagrams.py --check         # exit 1 if any page is stale
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def repo_root():
+    """The docs repository, resolved from the working directory.
+
+    This script lives in the skills repo and runs against a docs repo, so the
+    root can never be derived from `__file__`.
+    """
+    out = subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                         capture_output=True, text=True)
+    if out.returncode:
+        sys.exit("not inside a git repository — run this from the docs repo")
+    root = Path(out.stdout.strip())
+    if not (root / "docs" / "modules").is_dir():
+        sys.exit(f"no docs/modules under {root} — run this from the docs repo")
+    return root
+
+
+REPO = repo_root()
+
+BEGIN = "<!-- gen:composition-diagram -->"
+END = "<!-- /gen:composition-diagram -->"
+
+# Mermaid node ids must not contain spaces or punctuation. A previous terminology
+# sweep broke two diagrams by substituting a spaced phrase into a node id, so ids
+# are derived mechanically here and never from prose.
+def node_id(slug: str) -> str:
+    return re.sub(r"[^A-Za-z0-9]", "_", slug).upper()
+
+
+def frontmatter_title(text: str, fallback: str) -> str:
+    m = re.search(r'^title:\s*"?([^"\n]+)"?\s*$', text, re.M)
+    return m.group(1).strip() if m else fallback
+
+
+def constituents(text: str) -> list[str]:
+    """Slugs listed under '# Constituent Modules', in order."""
+    m = re.search(r"^#+\s*Constituent Modules\s*$(.*?)(?=^#|\Z)", text, re.M | re.S)
+    if not m:
+        return []
+    out = []
+    # Only bullet-list links count. A prose link inside the section is a mention,
+    # not a constituent declaration.
+    for line in m.group(1).splitlines():
+        if not line.lstrip().startswith(("-", "*")):
+            continue
+        link = re.search(r"\]\(\.\./([A-Za-z0-9._-]+)/spec\.md", line)
+        if link and link.group(1) not in out:
+            out.append(link.group(1))
+    return out
+
+
+def load_graph():
+    """slug -> {title, constituents, path}. Only tracked pages."""
+    tracked = subprocess.run(
+        ["git", "-C", str(REPO), "ls-files", "docs/modules"],
+        capture_output=True, text=True, check=True).stdout.split()
+    graph = {}
+    for rel in tracked:
+        if not rel.endswith("/spec.md"):
+            continue
+        p = REPO / rel
+        slug = p.parent.name
+        text = p.read_text(encoding="utf-8")
+        graph[slug] = {
+            "title": frontmatter_title(text, slug),
+            "constituents": constituents(text),
+            "path": p,
+        }
+    return graph
+
+
+def descendants(slug, graph, seen=None):
+    """Every module reachable downward through composition. Cycle-safe."""
+    seen = seen or set()
+    if slug in seen:
+        return set()
+    seen.add(slug)
+    out = set()
+    for c in graph.get(slug, {}).get("constituents", []):
+        out.add(c)
+        out |= descendants(c, graph, seen)
+    return out
+
+
+def build_diagram(slug, graph):
+    """Mermaid block for one module's composition tree, or None if it has none."""
+    root = graph[slug]
+    if not root["constituents"]:
+        return None
+
+    involved = {slug} | descendants(slug, graph)
+    # keep only nodes we actually have pages for
+    involved = {s for s in involved if s in graph}
+
+    lines = [
+        "```mermaid",
+        "%%{init: {'theme': 'base', 'themeVariables': "
+        "{'lineColor': '#555555', 'edgeLabelBackground': '#ffffff'}}}%%",
+        "flowchart TD",
+    ]
+
+    for s in sorted(involved):
+        label = graph[s]["title"].replace('"', "'")
+        lines.append(f'    {node_id(s)}["{label}"]')
+
+    lines.append("")
+    edges = []
+    for s in sorted(involved):
+        for c in graph[s]["constituents"]:
+            if c in involved:
+                edges.append(f"    {node_id(c)} --> {node_id(s)}")
+    lines += edges
+
+    lines.append("")
+    lines.append("    classDef constituent fill:#6B7280,color:#ffffff,stroke:#4B5563;")
+    lines.append("    classDef this fill:#374151,color:#ffffff,stroke:#111827;")
+    others = sorted(involved - {slug})
+    if others:
+        lines.append("    class " + ",".join(node_id(s) for s in others) + " constituent;")
+    lines.append(f"    class {node_id(slug)} this;")
+
+    lines.append("")
+    for s in sorted(involved):
+        lines.append(f"    click {node_id(s)} \"/docs/modules/{s}/spec\"")
+
+    lines.append("```")
+    return "\n".join(lines)
+
+
+def wrap(diagram, title):
+    """A tab-item, fenced at 4 colons to sit inside a 5-colon tab-set.
+
+    Emits the diagram and nothing else. Three explanatory paragraphs used to
+    follow it — how to read the arrows, a note that composition is not a claim
+    about integration, and a line telling the reader this block is generated.
+    They were removed because docs pages address the compositional biology
+    community, who are reading them as reference documentation: the first
+    restated what a clickable flowchart already shows, and the other two spoke
+    to editors rather than to that audience. The BEGIN/END markers already mark
+    the block as generated for anyone editing the source.
+    """
+    return (
+        f"{BEGIN}\n"
+        f"::::{{tab-item}} Module Dependencies\n\n"
+        f"{diagram}\n\n"
+        f"::::\n"
+        f"{END}"
+    )
+
+
+def existing_block(text):
+    m = re.search(re.escape(BEGIN) + r".*?" + re.escape(END), text, re.S)
+    return m
+
+
+def main():
+    write = "--write" in sys.argv
+    check = "--check" in sys.argv
+    graph = load_graph()
+
+    have, skipped, stale = [], [], []
+    outdir = REPO / "tmp" / "proposed-diagrams"
+    if not (write or check):
+        outdir.mkdir(parents=True, exist_ok=True)
+
+    for slug in sorted(graph):
+        diagram = build_diagram(slug, graph)
+        if diagram is None:
+            skipped.append(slug)
+            continue
+        have.append(slug)
+        block = wrap(diagram, graph[slug]["title"])
+        p = graph[slug]["path"]
+        text = p.read_text(encoding="utf-8")
+        m = existing_block(text)
+
+        if check:
+            if not m or m.group(0) != block:
+                stale.append(slug)
+            continue
+        if write:
+            if m:
+                p.write_text(text[:m.start()] + block + text[m.end():], encoding="utf-8")
+            else:
+                stale.append(slug)  # no marker yet: needs manual placement
+            continue
+        (outdir / f"{slug}.md").write_text(block + "\n", encoding="utf-8")
+
+    if check:
+        print(f"{len(have)} module(s) with a composition path")
+        if stale:
+            print(f"STALE or missing block ({len(stale)}):")
+            for s in stale:
+                print(f"  {s}")
+            return 1
+        print("✅ all composition diagrams current")
+        return 0
+
+    print(f"modules with a composition path : {len(have)}")
+    for s in have:
+        n = len(descendants(s, graph) & set(graph))
+        print(f"    {s}  ({n} constituent(s), transitive)")
+    print(f"\nno constituents, skipped        : {len(skipped)}")
+    if write:
+        placed = len(have) - len(stale)
+        print(f"\nwritten into {placed} page(s)")
+        if stale:
+            print(f"no {BEGIN} marker found, so NOT written ({len(stale)}):")
+            for s in stale:
+                print(f"  {s}")
+            print("\nAdd the marker pair inside the page's tab-set, then re-run --write.")
+    else:
+        print(f"\nproposals written to {outdir.relative_to(REPO)}/ (nothing in docs/ touched)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/mermaid-diagrams/scripts/gen-subsystem-tree.py
+++ b/.claude/skills/mermaid-diagrams/scripts/gen-subsystem-tree.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+gen-subsystem-tree.py — dependency flowchart for a subsystem, from declared roots.
+
+Expands the given root modules transitively through the composition graph and
+emits a greyscale Mermaid flowchart containing only those modules.
+
+Rules this encodes, each of which came from getting it wrong first:
+
+  * Roots are declared, never scraped from links. Pages legitimately link to
+    modules they do not depend on — to explain an absence, or to contrast against
+    a different implementation. Scraping every link produces phantom nodes.
+  * Every node ends up a dependency of something in the diagram.
+  * Requirement edges ("must be present") are a different relation from
+    composition edges ("is made of"), and are drawn differently.
+  * Composition only. The diagram never asserts an integration is confirmed.
+  * Greyscale.
+
+Usage:
+    gen-subsystem-tree.py NAME ROOT [ROOT ...]
+    gen-subsystem-tree.py --orphans          # list modules nothing references
+
+    # a requirement edge: LEFT requires RIGHT
+    gen-subsystem-tree.py NAME ROOT --requires reporter:substrate
+
+    # drop a composition edge, e.g. a proposed alternative not actually used
+    gen-subsystem-tree.py NAME ROOT --exclude cascade:alt-reporter
+
+Run it twice for two subsystems, then diff the node lists to check one is a
+subset of the other.
+
+Output goes to tmp/proposed-diagrams/ by default. Nothing in the docs tree is
+touched — insertion into pages is a separate, reviewed step.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+MODULES_DIR = "docs/modules"
+OUT_DIR = "tmp/proposed-diagrams"
+
+
+def node_id(slug):
+    """Mermaid ids cannot contain spaces. Derive mechanically, never from prose."""
+    return re.sub(r"[^A-Za-z0-9]", "_", slug).upper()
+
+
+def repo_root():
+    out = subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                         capture_output=True, text=True)
+    if out.returncode:
+        sys.exit("not inside a git repository")
+    return Path(out.stdout.strip())
+
+
+def load_graph(repo, exclude):
+    """slug -> {title, cons}. Tracked files only, so build artifacts stay out."""
+    tracked = subprocess.run(["git", "-C", str(repo), "ls-files", MODULES_DIR],
+                             capture_output=True, text=True, check=True).stdout.split()
+    graph = {}
+    for rel in tracked:
+        if not rel.endswith("/spec.md"):
+            continue
+        path = repo / rel
+        slug = path.parent.name
+        text = path.read_text(encoding="utf-8")
+        title = re.search(r'^title:\s*"?([^"\n]+)"?\s*$', text, re.M)
+        section = re.search(r"^#+\s*Constituent Modules\s*$(.*?)(?=^#|\Z)",
+                            text, re.M | re.S)
+        cons = []
+        if section:
+            # Only bullet-list links count. A prose sentence inside the section
+            # ("both paths terminate at X") is not a constituent declaration —
+            # counting it inflates the graph with things the module merely
+            # mentions.
+            for line in section.group(1).splitlines():
+                if not line.lstrip().startswith(("-", "*")):
+                    continue
+                link = re.search(r"\]\(\.\./([A-Za-z0-9._-]+)/spec\.md", line)
+                if not link:
+                    continue
+                c = link.group(1)
+                if c not in cons and (slug, c) not in exclude:
+                    cons.append(c)
+        graph[slug] = {"title": title.group(1).strip() if title else slug,
+                       "cons": cons}
+    return graph
+
+
+def closure(roots, graph, requires):
+    seen, stack = set(), list(roots)
+    while stack:
+        slug = stack.pop()
+        if slug in seen or slug not in graph:
+            continue
+        seen.add(slug)
+        stack.extend(graph[slug]["cons"])
+        stack.extend(r for m, r in requires if m == slug)
+    return seen
+
+
+def emit(nodes, graph, requires, caption):
+    out = ["```mermaid",
+           "%%{init: {'theme': 'base', 'themeVariables': "
+           "{'lineColor': '#555555', 'edgeLabelBackground': '#ffffff'}}}%%",
+           "flowchart TD"]
+
+    for slug in sorted(nodes):
+        out.append(f'    {node_id(slug)}["{graph[slug]["title"]}"]')
+    out.append("")
+
+    for slug in sorted(nodes):
+        for c in graph[slug]["cons"]:
+            if c in nodes:
+                out.append(f"    {node_id(c)} --> {node_id(slug)}")
+    for m, r in sorted(requires):
+        if m in nodes and r in nodes:
+            out.append(f"    {node_id(r)} -.->|requires| {node_id(m)}")
+    out.append("")
+
+    leaves = sorted(s for s in nodes if not graph[s]["cons"])
+    composed = sorted(s for s in nodes if graph[s]["cons"])
+    out.append("    classDef leaf     fill:#e5e7eb,stroke:#6b7280,color:#111827;")
+    out.append("    classDef composed fill:#6b7280,stroke:#374151,color:#ffffff;")
+    if leaves:
+        out.append("    class " + ",".join(node_id(s) for s in leaves) + " leaf;")
+    if composed:
+        out.append("    class " + ",".join(node_id(s) for s in composed) + " composed;")
+    out.append("")
+
+    for slug in sorted(nodes):
+        out.append(f'    click {node_id(slug)} "/docs/modules/{slug}/spec"')
+    out.append("```")
+    out.append("")
+    out.append(caption)
+    return "\n".join(out)
+
+
+def pairs(values):
+    result = set()
+    for v in values or []:
+        if ":" not in v:
+            sys.exit(f"expected LEFT:RIGHT, got {v!r}")
+        a, b = v.split(":", 1)
+        result.add((a.strip(), b.strip()))
+    return result
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("name", nargs="?", help="subsystem name, used in the caption")
+    ap.add_argument("roots", nargs="*", help="module slugs to expand from")
+    ap.add_argument("--requires", action="append", metavar="LEFT:RIGHT")
+    ap.add_argument("--exclude", action="append", metavar="LEFT:RIGHT")
+    ap.add_argument("--orphans", action="store_true",
+                    help="list modules nothing references — candidate roots")
+    args = ap.parse_args()
+
+    repo = repo_root()
+    graph = load_graph(repo, pairs(args.exclude))
+    requires = pairs(args.requires)
+
+    if args.orphans:
+        referenced = {c for v in graph.values() for c in v["cons"]}
+        tops = sorted(s for s in graph if s not in referenced)
+        print(f"referenced by nothing ({len(tops)}) — candidate roots:")
+        for s in tops:
+            print(f"    {s}  ({len(graph[s]['cons'])} constituent(s))")
+        return 0
+
+    if not args.name or not args.roots:
+        ap.print_help()
+        return 2
+
+    unknown = [r for r in args.roots if r not in graph]
+    if unknown:
+        sys.exit(f"unknown root(s): {unknown}")
+
+    nodes = closure(args.roots, graph, requires)
+    caption = (f"Module dependency tree for {args.name}. Every node is a dependency "
+               f"of something shown. This diagram shows composition only — it does "
+               f"not assert that any integration is confirmed.")
+
+    outdir = repo / OUT_DIR
+    outdir.mkdir(parents=True, exist_ok=True)
+    slug = re.sub(r"[^a-z0-9]+", "-", args.name.lower()).strip("-")
+    dest = outdir / f"tree-{slug}.md"
+    dest.write_text(emit(nodes, graph, requires, caption) + "\n", encoding="utf-8")
+
+    print(f"{args.name}: {len(nodes)} module(s)")
+    for s in sorted(nodes):
+        print(f"    {s}")
+    print(f"\nwritten to {dest.relative_to(repo)}")
+    print("nothing in the docs tree was touched")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/assemble-module-graph-artifact.py
+++ b/scripts/assemble-module-graph-artifact.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+assemble-module-graph-artifact.py — Layer 4b: substitute freshly rendered
+Mermaid blocks into the artifact's HTML shell.
+
+Runs render-module-graph.py, then drops each of the six diagrams into its
+`{{MERMAID:<key>}}` placeholder in module-graph-template.html. The shell
+itself (design, CSS, pan/zoom script, and the surrounding curated prose in
+"Reading the edges") is not regenerated -- only the six diagrams are data-
+driven. The prose is its own kind of Layer 3: synthesis a human writes, not
+structure a script emits, and it doesn't go stale the way a diagram does
+every time a module's composition changes.
+
+Usage:
+    python3 scripts/assemble-module-graph-artifact.py --out module-graph.html
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).parent
+TEMPLATE = HERE / "module-graph-template.html"
+
+PLACEHOLDER_RE = re.compile(r"\{\{MERMAID:(\w+)\}\}")
+
+
+def render_blocks(out_dir: Path) -> dict:
+    out = subprocess.run(
+        [sys.executable, str(HERE / "render-module-graph.py"), "--out-dir", str(out_dir)],
+        capture_output=True,
+        text=True,
+    )
+    if out.returncode != 0:
+        sys.exit(f"render-module-graph.py failed:\n{out.stderr}")
+    print(out.stdout)
+
+    blocks = {}
+    for path in out_dir.glob("*.md"):
+        key = path.stem.replace("-", "_")
+        text = path.read_text().strip()
+        # Strip the ```mermaid / ``` fence -- the HTML shell's own
+        # <pre class="mermaid"> tag is the fence equivalent here.
+        lines = text.splitlines()
+        if lines[0].strip() == "```mermaid" and lines[-1].strip() == "```":
+            lines = lines[1:-1]
+        blocks[key] = "\n".join(lines)
+    return blocks
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--blocks-dir", type=Path, default=Path("tmp/mermaid-blocks"))
+    args = ap.parse_args()
+
+    blocks = render_blocks(args.blocks_dir)
+    html = TEMPLATE.read_text()
+
+    missing = []
+
+    def replace(m):
+        key = m.group(1)
+        if key not in blocks:
+            missing.append(key)
+            return m.group(0)
+        return blocks[key]
+
+    html = PLACEHOLDER_RE.sub(replace, html)
+    if missing:
+        sys.exit(f"no rendered block for placeholder(s): {missing}")
+
+    args.out.write_text(html)
+    print(f"wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate-module-graph.py
+++ b/scripts/generate-module-graph.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""
+generate-module-graph.py — Layer 1+2 of the module-integration-map pipeline.
+
+Layer 1 (not mine): composition structure, read the same way the
+nucleus-skills `mermaid-diagrams` skill reads it — bullet-list links under
+each page's own `# Constituent Modules` section. This script re-implements
+that one parsing function rather than importing the vendored skill script,
+since the skill scripts are CLI tools that write their own files; the
+functions themselves are small and stable (see
+.claude/skills/mermaid-diagrams/scripts/gen-subsystem-tree.py).
+
+Layer 2 (this script's real job): merge in what the skill does not cover —
+  - module class + validation stars, from the tables in modules-main.md
+  - family membership: either a real composition closure from a declared
+    root, or a declared flat list for pages that don't have a Constituent
+    Modules section yet (see FAMILY_CONFIG below for which mode each
+    family uses and why)
+
+This script does NOT decide status (confirmed/proposed/blocked), draw
+requirement edges, or add curated annotations (disambiguation notes,
+substitute-module claims, conflict edges). That is Layer 3 — see
+module-graph-annotations.yaml — merged in by render-module-graph.py.
+
+Usage:
+    python3 scripts/generate-module-graph.py --out module-report.json
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+DOCS_MODULES = Path("docs/modules")
+MODULES_MAIN = DOCS_MODULES / "modules-main.md"
+
+FRONTMATTER_TITLE_RE = re.compile(r'^title:\s*(?:"([^"]*)"|\'([^\']*)\'|(.*))$')
+TABLE_ROW_RE = re.compile(
+    r"^\|\s*([^|]*)\|\s*\[([^\]]+)\]\(([^)]+)\)\s*\|\s*([^|]*)\|"
+)
+CONSTITUENT_SECTION_RE = re.compile(
+    r"^#+\s*Constituent Modules\s*$(.*?)(?=^#|\Z)", re.M | re.S
+)
+CONSTITUENT_LINK_RE = re.compile(r"\]\(\.\./([A-Za-z0-9._-]+)/spec\.md")
+
+# Family membership. `mode: closure` expands a declared root transitively
+# through composition, same as gen-subsystem-tree.py would; `mode: flat`
+# is a declared list for a family whose pages don't have a Constituent
+# Modules section yet (see each family's "reason" for why it's flat
+# rather than closure-derived -- nucleus-docs PR #221 fixed this for two
+# pages, but that hasn't merged as of this writing).
+FAMILY_CONFIG = {
+    "shared": {
+        "mode": "flat",
+        "display_name": "Shared &amp; Base",
+        "reason": "base modules predate the Constituent Modules "
+        "convention -- base-cell is genuinely composed of Base Cytosol + "
+        "Base Membrane (its Reference Composition table says so), but "
+        "that isn't in a machine-readable bullet list yet, so a closure "
+        "from it would see zero constituents. Left flat rather than "
+        "silently rendering Base Cell as an unconnected leaf.",
+        "members": [
+            "base-cytosol",
+            "membrane-popc-chol",
+            "base-cell",
+            "dye-liposomes",
+            "reporter-degfp",
+        ],
+    },
+    "purex": {
+        "mode": "flat",
+        "display_name": "PURExpress",
+        "reason": "leaf modules with no constituents at all -- not "
+        "composed into anything, so a closure has nothing to expand.",
+        "members": [
+            "detector-tetr_atc",
+            "detector-laci_iptg",
+            "emitter-ivhsl",
+            "control-clpxp",
+            "energy-ppk",
+            "membrane-pore-ahly",
+            "membrane-pore-cx43",
+        ],
+    },
+}
+
+
+def repo_root() -> Path:
+    out = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True
+    )
+    if out.returncode:
+        sys.exit("not inside a git repository")
+    return Path(out.stdout.strip())
+
+
+def extract_title(text: str, fallback: str) -> str:
+    if not text.startswith("---"):
+        return fallback
+    end = text.find("\n---", 3)
+    if end == -1:
+        return fallback
+    for line in text[3:end].splitlines():
+        m = FRONTMATTER_TITLE_RE.match(line.strip())
+        if m:
+            return next(g for g in m.groups() if g is not None).strip()
+    return fallback
+
+
+def constituents(text: str) -> list:
+    """Slugs under '# Constituent Modules', bullet-list links only.
+
+    Same rule as the mermaid-diagrams skill: a prose link inside the
+    section is a mention, not a declared constituent.
+    """
+    m = CONSTITUENT_SECTION_RE.search(text)
+    if not m:
+        return []
+    out = []
+    for line in m.group(1).splitlines():
+        if not line.lstrip().startswith(("-", "*")):
+            continue
+        link = CONSTITUENT_LINK_RE.search(line)
+        if link and link.group(1) not in out:
+            out.append(link.group(1))
+    return out
+
+
+def load_composition_graph(repo: Path) -> dict:
+    """slug -> {title, constituents, path}. Tracked files only."""
+    tracked = subprocess.run(
+        ["git", "-C", str(repo), "ls-files", "docs/modules"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.split()
+    graph = {}
+    for rel in tracked:
+        if not rel.endswith(".md") or rel.endswith("modules-main.md"):
+            continue
+        p = repo / rel
+        stem = p.stem
+        if stem != "spec" and not stem.endswith("-spec"):
+            continue
+        slug = p.parent.name if stem == "spec" else stem
+        text = p.read_text(encoding="utf-8")
+        graph[slug] = {
+            "title": extract_title(text, slug),
+            "constituents": constituents(text),
+            "path": str(p.relative_to(repo)),
+        }
+    return graph
+
+
+def descendants(slug: str, graph: dict, seen=None) -> set:
+    seen = seen if seen is not None else set()
+    if slug in seen:
+        return set()
+    seen.add(slug)
+    out = set()
+    for c in graph.get(slug, {}).get("constituents", []):
+        out.add(c)
+        out |= descendants(c, graph, seen)
+    return out
+
+
+def parse_modules_main(repo: Path) -> dict:
+    path = repo / MODULES_MAIN
+    if not path.exists():
+        print(f"warning: {MODULES_MAIN} not found", file=sys.stderr)
+        return {}
+    result = {}
+    current_chassis = None
+    last_class = ""
+    for line in path.read_text(encoding="utf-8").splitlines():
+        heading = re.match(r"^##\s+(.+)$", line)
+        if heading:
+            current_chassis = heading.group(1).strip()
+            last_class = ""
+            continue
+        m = TABLE_ROW_RE.match(line)
+        if not m:
+            continue
+        module_class, _text, target, validation = m.groups()
+        module_class = module_class.strip() or last_class
+        if module_class:
+            last_class = module_class
+        if target.startswith("http"):
+            continue
+        slug = re.sub(r"^\./", "", target)
+        slug = re.sub(r"/spec\.md.*$", "", slug)
+        result[slug] = {
+            "class": module_class,
+            "validation": validation.strip(),
+            "chassis": current_chassis,
+        }
+    return result
+
+
+def resolve_families(graph: dict) -> dict:
+    """family_name -> sorted list of member slugs, per FAMILY_CONFIG."""
+    families = {}
+    for name, cfg in FAMILY_CONFIG.items():
+        if cfg["mode"] == "flat":
+            families[name] = sorted(cfg["members"])
+        elif cfg["mode"] == "closure":
+            members = set(cfg["roots"])
+            for root in cfg["roots"]:
+                members |= descendants(root, graph)
+            families[name] = sorted(s for s in members if s in graph)
+        else:
+            sys.exit(f"unknown family mode: {cfg['mode']}")
+    return families
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", type=Path, default=None)
+    args = ap.parse_args()
+
+    repo = repo_root()
+    graph = load_composition_graph(repo)
+    table_data = parse_modules_main(repo)
+    families = resolve_families(graph)
+
+    # sanity: every family member should actually exist in the composition
+    # graph (i.e. we found a spec page for it)
+    for name, members in families.items():
+        missing = [s for s in FAMILY_CONFIG[name].get("members", members) if s not in graph]
+        for s in missing:
+            print(f"warning: family '{name}' declares '{s}' but no spec page was found", file=sys.stderr)
+
+    modules = {}
+    for slug, data in graph.items():
+        meta = table_data.get(slug, {})
+        modules[slug] = {
+            "title": data["title"],
+            "path": data["path"],
+            "constituents": data["constituents"],
+            "class": meta.get("class"),
+            "validation": meta.get("validation"),
+            "chassis": meta.get("chassis"),
+            "in_modules_main": slug in table_data,
+        }
+
+    report = {
+        "families": {
+            name: {
+                "mode": FAMILY_CONFIG[name]["mode"],
+                "display_name": FAMILY_CONFIG[name].get("display_name", name),
+                "direction": FAMILY_CONFIG[name].get("direction", "TD"),
+                "reason": FAMILY_CONFIG[name].get("reason"),
+                "roots": FAMILY_CONFIG[name].get("roots"),
+                "members": members,
+            }
+            for name, members in families.items()
+        },
+        "modules": modules,
+    }
+
+    output = json.dumps(report, indent=2, sort_keys=True)
+    if args.out:
+        args.out.write_text(output + "\n", encoding="utf-8")
+        print(f"wrote {args.out} ({len(modules)} modules, {len(families)} families)")
+    else:
+        print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/module-graph-annotations.yaml
+++ b/scripts/module-graph-annotations.yaml
@@ -1,0 +1,93 @@
+# module-graph-annotations.yaml — Layer 3 of the module-integration-map pipeline.
+#
+# Everything in this file required reading prose to decide. None of it is
+# re-derivable by re-running generate-module-graph.py against a changed
+# module set — when modules change, a human (or an agent reading the new
+# prose) re-checks and edits this file by hand. That is the point of
+# splitting it out: Layers 1-2 are safe to regenerate blindly; this layer
+# never is.
+#
+# Schema mirrors the mermaid-diagrams skill's own status conventions
+# (SKILL.md: confirmed --> / proposed -.-> / blocked --x) plus two edge
+# kinds the skill's generators don't draw at all (substitute, assay) that
+# came up reading these specific pages.
+#
+# Scoped to the 12 modules on `main` as of this writing. If a branch with
+# more modules (e.g. one adding a demo cascade) merges, this file needs
+# new entries for whatever it adds -- it will not silently cover new
+# content on its own.
+
+# LEFT requires RIGHT, same direction/meaning as gen-subsystem-tree.py's
+# `--requires LEFT:RIGHT` flag. Drawn as RIGHT -.->|requires| LEFT.
+#
+# `family` says which family's diagram draws this edge -- always the
+# family LEFT (the requiring module) actually belongs to, even when RIGHT
+# is a member of a different family too (declared, not inferred: base-
+# cytosol and membrane-popc-chol are each members of "shared", but the
+# edge belongs to "purex", the family of the module doing the requiring).
+requires:
+  - {left: detector-tetr_atc,   right: base-cytosol,        family: purex, why: "assembled in a standard PURE reaction"}
+  - {left: emitter-ivhsl,       right: base-cytosol,        family: purex, why: "assembled in a standard PURE reaction"}
+  - {left: membrane-pore-ahly,  right: base-cytosol,        family: purex, why: "assembled following Assemble Base Cytosol"}
+  - {left: membrane-pore-ahly,  right: membrane-popc-chol,  family: purex, why: "pore insertion needs a lipid bilayer"}
+  - {left: membrane-pore-cx43,  right: membrane-popc-chol,  family: purex, why: "cannot be functionally deployed in Nucleus Cytosol alone (spec's own words)"}
+
+# Not composition, not a build requirement -- a claim about the modules'
+# relationship that's still worth drawing, with its own edge style. Same
+# "one home diagram, declared not inferred" rule as requires.
+extra_edges:
+  - from: membrane-pore-ahly
+    to: membrane-pore-cx43
+    family: purex
+    style: substitute
+    label: "safer alternative"
+    why: "aHly spec names Cx43 as functionally comparable without the BSL-2 handling requirement, and flags itself as not actively supported"
+  - from: detector-tetr_atc
+    to: emitter-ivhsl
+    family: purex
+    style: implementation
+    label: "combined in responder-atc-ivhsl"
+    why: "nothing in either module's own spec links them -- they only co-occur in implementations/responder-atc-ivhsl/main.md"
+  - from: control-clpxp
+    to: reporter-degfp
+    family: purex
+    style: assay
+    label: "reads out via deGFP-ssrA"
+    why: "ClpXP's own reaction tables run on purified deGFP-ssrA as the degradation reporter -- an assay reagent, not a composed module"
+
+# No status overrides on `main` -- both real composition edges here
+# (Base Membrane/Base Cytosol -> Base Cell, -> deGFP) are validated ★★★
+# per modules-main.md, and Base Cell has no Constituent Modules section
+# yet anyway (see generate-module-graph.py's FAMILY_CONFIG), so there is
+# currently no composition edge in the graph to override.
+edge_status: []
+
+# `--x` per the skill's convention: the strongest available claim
+# (something does NOT work), so it needs the strongest evidence -- see
+# SKILL.md's "Evidence proportional to claim". None found on `main` --
+# no module page here documents a blocked combination.
+conflicts: []
+
+# fill/stroke for a node beyond the skill's default leaf/composed
+# greyscale -- reserved for a real distinction: not supported, or shelved
+# out of active use. Values: unsupported | shelved
+node_status:
+  membrane-pore-ahly: unsupported          # BSL-2, "not actively supported" per its own spec
+
+# Display title overrides where the frontmatter title carries doc
+# boilerplate a diagram shouldn't repeat. None needed on `main` -- every
+# title here is already the concise form (e.g. "Detector: tetR-aTc").
+title_overrides: {}
+
+# Page-level callouts that apply to the whole map, not one edge. None
+# needed on `main` -- the AHL/aHly/IV-HSL naming trap only becomes live
+# once a LuxR/pLux "AHL" detector module exists (it doesn't here); aHly
+# and IV-HSL alone don't collide on the word "AHL".
+disambiguation_notes: []
+
+# Coarse edges for the top-level system-map (family boxes, not individual
+# modules). Not derivable from the module graph -- it's a summary of
+# which families reach into the Shared bucket, decided by a human reading
+# what each family's modules actually use.
+system_map_edges:
+  - {from: shared, to: purex, label: "assembly + reporters"}

--- a/scripts/module-graph-template.html
+++ b/scripts/module-graph-template.html
@@ -1,0 +1,575 @@
+<title>Module Integration Map</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap">
+
+<style>
+  :root {
+    --bg: #f4f6f2;
+    --surface: #ffffff;
+    --surface-2: #eceee6;
+    --ink: #1c2b28;
+    --ink-dim: #52645f;
+    --line: #cdd8ce;
+    --accent-purex: #CC79A7;
+    --accent-shared: #D55E00;
+    --danger: #a3403a;
+    --warn-bg: #f6e9db;
+    --warn-ink: #7a4a1f;
+    --shadow: rgba(28, 43, 40, 0.08);
+    --toolbar-bg: #eceee6;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --bg: #0e1613;
+      --surface: #152420;
+      --surface-2: #1b2b26;
+      --ink: #e8efe9;
+      --ink-dim: #9fb3ac;
+      --line: #2c3f38;
+      --accent-purex: #e3a3c4;
+      --accent-shared: #e8a06b;
+      --danger: #d97a72;
+      --warn-bg: #2e2415;
+      --warn-ink: #e2b878;
+      --shadow: rgba(0, 0, 0, 0.4);
+      --toolbar-bg: #1b2b26;
+    }
+  }
+
+  :root[data-theme="dark"] {
+    --bg: #0e1613;
+    --surface: #152420;
+    --surface-2: #1b2b26;
+    --ink: #e8efe9;
+    --ink-dim: #9fb3ac;
+    --line: #2c3f38;
+    --accent-purex: #e3a3c4;
+    --accent-shared: #e8a06b;
+    --danger: #d97a72;
+    --warn-bg: #2e2415;
+    --warn-ink: #e2b878;
+    --shadow: rgba(0, 0, 0, 0.4);
+    --toolbar-bg: #1b2b26;
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: "IBM Plex Sans", system-ui, sans-serif;
+    line-height: 1.55;
+  }
+
+  .page {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 48px 32px 72px;
+  }
+
+  header.hero {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    margin-bottom: 36px;
+  }
+
+  .eyebrow {
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 12.5px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--accent-shared);
+  }
+
+  h1 {
+    font-family: "Fraunces", serif;
+    font-optical-sizing: auto;
+    font-weight: 600;
+    font-size: clamp(32px, 4.4vw, 46px);
+    margin: 0;
+    text-wrap: balance;
+    letter-spacing: -0.01em;
+  }
+
+  h2.section-title {
+    font-family: "Fraunces", serif;
+    font-weight: 600;
+    font-size: 15px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--ink-dim);
+    margin: 56px 0 6px;
+  }
+
+  .lede {
+    max-width: 70ch;
+    color: var(--ink-dim);
+    font-size: 16px;
+    margin: 0;
+  }
+
+  .lede strong { color: var(--ink); font-weight: 600; }
+  .lede code {
+    font-family: "IBM Plex Mono", monospace;
+    background: var(--surface-2);
+    padding: 1px 5px;
+    border-radius: 4px;
+    font-size: 0.9em;
+    color: var(--ink);
+  }
+
+  .legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 6px;
+  }
+
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    padding: 6px 12px;
+    border-radius: 100px;
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 12px;
+    font-weight: 500;
+    border: 1px solid var(--line);
+    background: var(--surface);
+  }
+
+  .chip .dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    flex: none;
+  }
+
+  .dot.purex { background: var(--accent-purex); }
+  .dot.shared { background: var(--accent-shared); }
+  .dot.danger { background: var(--danger); }
+
+  .panel {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 18px;
+    box-shadow: 0 1px 2px var(--shadow);
+    padding: 24px 24px 20px;
+    margin-bottom: 22px;
+  }
+
+  .panel h2 {
+    font-family: "Fraunces", serif;
+    font-weight: 600;
+    font-size: 19px;
+    margin: 0 0 3px;
+  }
+
+  .panel .sub {
+    color: var(--ink-dim);
+    font-size: 13.5px;
+    margin: 0 0 16px;
+  }
+
+  .callout {
+    display: flex;
+    gap: 10px;
+    background: var(--warn-bg);
+    color: var(--warn-ink);
+    border-radius: 12px;
+    padding: 12px 16px;
+    font-size: 13.5px;
+    margin-bottom: 16px;
+  }
+
+  .callout b { color: inherit; }
+
+  /* --- diagram frame: toolbar + pan/zoom viewport --- */
+  .diagram-frame {
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    overflow: hidden;
+    background: var(--surface);
+  }
+
+  .diagram-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    background: var(--toolbar-bg);
+    border-bottom: 1px solid var(--line);
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 11.5px;
+    color: var(--ink-dim);
+  }
+
+  .diagram-toolbar button {
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 13px;
+    line-height: 1;
+    width: 26px;
+    height: 26px;
+    border-radius: 6px;
+    border: 1px solid var(--line);
+    background: var(--surface);
+    color: var(--ink);
+    cursor: pointer;
+  }
+
+  .diagram-toolbar button:hover { background: var(--surface-2); }
+
+  .diagram-toolbar .hint {
+    margin-left: auto;
+    font-size: 11px;
+    opacity: 0.8;
+  }
+
+  .diagram-viewport {
+    overflow: hidden;
+    touch-action: none;
+    cursor: grab;
+    height: 340px;
+    position: relative;
+    user-select: none;
+    -webkit-user-select: none;
+    overscroll-behavior: contain;
+  }
+
+  .diagram-viewport.short { height: 200px; }
+
+  .diagram-viewport.grabbing { cursor: grabbing; }
+
+  /* This wrapper, not mermaid's own output, is what gets transformed --
+     mermaid is free to replace its own pre/svg internals without ever
+     invalidating the pan/zoom target. */
+  .diagram-inner {
+    display: inline-block;
+    transform-origin: 0 0;
+    will-change: transform;
+  }
+
+  .diagram-viewport pre.mermaid {
+    margin: 0;
+  }
+
+  .key-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 14px;
+    margin-top: 18px;
+  }
+
+  .key-item {
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+    font-size: 13.5px;
+    color: var(--ink-dim);
+  }
+
+  .key-item .swatch {
+    flex: none;
+    width: 30px;
+    height: 3px;
+    margin-top: 8px;
+    border-radius: 2px;
+  }
+
+  .swatch.solid { background: var(--ink-dim); }
+  .swatch.bold { background: var(--ink-dim); height: 4px; }
+  .swatch.dotted {
+    background: repeating-linear-gradient(to right, var(--accent-shared) 0 3px, transparent 3px 6px);
+  }
+  .swatch.ext {
+    background: repeating-linear-gradient(to right, var(--ink-dim) 0 4px, transparent 4px 7px);
+    height: 2px;
+    border: none;
+  }
+  .swatch.status {
+    height: 2px;
+    border-top: 2px dashed var(--danger);
+  }
+
+  .key-item b { color: var(--ink); font-weight: 600; }
+
+  .notes {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(270px, 1fr));
+    gap: 18px;
+  }
+
+  .note h3 {
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 12.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--accent-shared);
+    margin: 0 0 8px;
+  }
+
+  .note p {
+    margin: 0;
+    font-size: 14px;
+    color: var(--ink-dim);
+  }
+
+  .note code {
+    font-family: "IBM Plex Mono", monospace;
+    background: var(--surface-2);
+    padding: 1px 5px;
+    border-radius: 4px;
+    font-size: 12.5px;
+    color: var(--ink);
+  }
+
+  footer {
+    color: var(--ink-dim);
+    font-size: 12.5px;
+    text-align: center;
+    margin-top: 8px;
+  }
+</style>
+
+<div class="page">
+  <header class="hero">
+    <div class="eyebrow">Nucleus Distribution &middot; docs/modules</div>
+    <h1>Module Integration Map</h1>
+    <p class="lede">
+      Every module spec under <code>docs/modules/</code>, and how they actually
+      connect &mdash; generated, not hand-drawn. Composition and requirement edges
+      come straight from each module's own <code>modules-main.md</code> entry and
+      the <code>mermaid-diagrams</code> skill's parsing rules; anything that
+      needed reading prose to decide (status, substitutions, conflicts) is a
+      separate, hand-curated layer on top. See
+      <code>scripts/generate-module-graph.py</code>,
+      <code>scripts/module-graph-annotations.yaml</code>, and
+      <code>scripts/render-module-graph.py</code> for the pipeline that built this page.
+    </p>
+    <div class="legend">
+      <span class="chip"><span class="dot shared"></span> Shared &amp; Base</span>
+      <span class="chip"><span class="dot purex"></span> PURExpress</span>
+      <span class="chip"><span class="dot danger"></span> Unsupported</span>
+    </div>
+  </header>
+
+  <section class="panel">
+    <h2>System map</h2>
+    <p class="sub">Two families today. Scroll to either section below for the full breakdown.</p>
+    <div class="diagram-frame">
+      <div class="diagram-toolbar">
+        <button data-zoom="out" aria-label="Zoom out">&minus;</button>
+        <button data-zoom="in" aria-label="Zoom in">+</button>
+        <button data-zoom="reset" aria-label="Reset view">Reset</button>
+        <span class="hint">scroll to zoom &middot; drag to pan</span>
+      </div>
+      <div class="diagram-viewport short">
+        <div class="diagram-inner">
+<pre class="mermaid">
+{{MERMAID:system_map}}
+</pre>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <h2 class="section-title">Family 1 of 2</h2>
+  <section class="panel">
+    <h2>Shared &amp; base modules</h2>
+    <p class="sub">Validated in Nucleus Cytosol: the cytosol, membrane, cell, dye, and reporter that everything else in this table builds on or borrows from.</p>
+    <div class="diagram-frame">
+      <div class="diagram-toolbar">
+        <button data-zoom="out" aria-label="Zoom out">&minus;</button>
+        <button data-zoom="in" aria-label="Zoom in">+</button>
+        <button data-zoom="reset" aria-label="Reset view">Reset</button>
+        <span class="hint">scroll to zoom &middot; drag to pan</span>
+      </div>
+      <div class="diagram-viewport">
+        <div class="diagram-inner">
+<pre class="mermaid">
+{{MERMAID:shared}}
+</pre>
+        </div>
+      </div>
+    </div>
+    <p class="sub" style="margin-top:14px;">
+      No composition edges are drawn here yet &mdash; Base Cell is genuinely composed
+      of Base Cytosol + Base Membrane (its Reference Composition table says so),
+      but that isn't yet in the machine-readable <code>&num; Constituent Modules</code>
+      bullet-list form the pipeline reads. Rather than infer it, the diagram
+      shows exactly what's currently declared: nothing. See
+      <code>generate-module-graph.py</code>'s <code>FAMILY_CONFIG</code> for
+      the reasoning.
+    </p>
+  </section>
+
+  <h2 class="section-title">Family 2 of 2</h2>
+  <section class="panel">
+    <h2>PURExpress &mdash; the flat kit</h2>
+    <p class="sub">Modules validated in NEB PURExpress directly. None of these are assembled into a named cell in the docs &mdash; each is its own standalone reaction. Dashed circles are Shared-family modules shown again for context.</p>
+    <div class="diagram-frame">
+      <div class="diagram-toolbar">
+        <button data-zoom="out" aria-label="Zoom out">&minus;</button>
+        <button data-zoom="in" aria-label="Zoom in">+</button>
+        <button data-zoom="reset" aria-label="Reset view">Reset</button>
+        <span class="hint">scroll to zoom &middot; drag to pan</span>
+      </div>
+      <div class="diagram-viewport">
+        <div class="diagram-inner">
+<pre class="mermaid">
+{{MERMAID:purex}}
+</pre>
+        </div>
+      </div>
+    </div>
+    <div class="key-grid">
+      <div class="key-item"><span class="swatch ext"></span> <span><b>Dashed circle</b> &mdash; a module that lives in the Shared family, shown here only because a PURExpress module requires it</span></div>
+      <div class="key-item"><span class="swatch status"></span> <span><b>Dashed node border</b> &mdash; a documented status, not a family (Membrane Pore: &alpha;-Hemolysin is BSL-2 and "not actively supported" per its own spec)</span></div>
+    </div>
+  </section>
+
+  <section class="panel">
+    <h2>Reading the edges</h2>
+    <p class="sub">What each connection is actually backed by in the docs.</p>
+    <div class="key-grid">
+      <div class="key-item"><span class="swatch solid"></span> <span><b>Solid arrow</b> &mdash; confirmed composition (points from constituent into what contains it)</span></div>
+      <div class="key-item"><span class="swatch bold"></span> <span><b>Bold arrow</b> &mdash; only known to co-occur inside a documented implementation</span></div>
+      <div class="key-item"><span class="swatch dotted"></span> <span><b>Dotted arrow</b> &mdash; requirement, substitution, or indirect readout &mdash; not a build dependency</span></div>
+    </div>
+    <div class="notes" style="margin-top:22px;">
+      <div class="note">
+        <h3>Cx43 needs a bilayer</h3>
+        <p><code>membrane-pore-cx43/spec.md</code> states it "cannot be functionally deployed in Nucleus Cytosol alone" &mdash; it needs the POPC/Chol membrane for pore assembly. Same constraint applies to &alpha;-Hemolysin.</p>
+      </div>
+      <div class="note">
+        <h3>&alpha;-Hemolysin &rarr; Cx43 is a stated substitution</h3>
+        <p>The &alpha;-Hemolysin spec names Cx43 as "a functionally comparable alternative" without the BSL-2 handling requirement, and flags itself as not actively supported.</p>
+      </div>
+      <div class="note">
+        <h3>tetR-aTc + IV-HSL only met in one page</h3>
+        <p>Nothing in either module's own spec links them. They appear together only in <code>implementations/responder-atc-ivhsl/main.md</code>, which cites both specs directly.</p>
+      </div>
+      <div class="note">
+        <h3>ClpXP's readout is borrowed</h3>
+        <p>ClpXP's own reaction tables run on purified <code>deGFP-ssrA</code> as the degradation reporter &mdash; it doesn't compose deGFP as a module, it consumes it as an assay reagent.</p>
+      </div>
+      <div class="note">
+        <h3>LacI-IPTG isn't in the index yet</h3>
+        <p>It has a full <code>spec.md</code> but doesn't appear in either table in <code>modules-main.md</code>.</p>
+      </div>
+      <div class="note">
+        <h3>PPK stands alone</h3>
+        <p>Energy/PPK is listed in the PURExpress table but its spec makes no cross-reference to any other module &mdash; no composition or substitution claim found.</p>
+      </div>
+    </div>
+  </section>
+
+  <footer>Generated from docs/modules/*/spec.md and docs/modules/modules-main.md by scripts/assemble-module-graph-artifact.py &middot; edges reflect explicit text, not name-similarity</footer>
+</div>
+
+<script>
+(function () {
+  function initFrame(frame) {
+    if (frame.dataset.pzInit) return;
+    var viewport = frame.querySelector('.diagram-viewport');
+    var target = frame.querySelector('.diagram-inner');
+    if (!viewport || !target) return;
+
+    var state = { scale: 1, x: 16, y: 16 };
+
+    function apply() {
+      target.style.transform = 'translate(' + state.x + 'px,' + state.y + 'px) scale(' + state.scale + ')';
+    }
+
+    function clampScale(s) {
+      return Math.max(0.3, Math.min(4, s));
+    }
+
+    function zoomBy(factor, cx, cy) {
+      var rect = viewport.getBoundingClientRect();
+      var px = (cx !== undefined ? cx - rect.left : rect.width / 2);
+      var py = (cy !== undefined ? cy - rect.top : rect.height / 2);
+      var newScale = clampScale(state.scale * factor);
+      var ratio = newScale / state.scale;
+      state.x = px - (px - state.x) * ratio;
+      state.y = py - (py - state.y) * ratio;
+      state.scale = newScale;
+      apply();
+    }
+
+    function reset() {
+      state.scale = 1;
+      state.x = 16;
+      state.y = 16;
+      apply();
+    }
+
+    target.style.transformOrigin = '0 0';
+    apply();
+
+    viewport.addEventListener('wheel', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      var factor = e.deltaY < 0 ? 1.12 : 1 / 1.12;
+      zoomBy(factor, e.clientX, e.clientY);
+    }, { passive: false });
+
+    var dragging = false, moved = false, lastX = 0, lastY = 0;
+    viewport.addEventListener('pointerdown', function (e) {
+      dragging = true;
+      moved = false;
+      lastX = e.clientX;
+      lastY = e.clientY;
+      viewport.classList.add('grabbing');
+      if (viewport.setPointerCapture) {
+        try { viewport.setPointerCapture(e.pointerId); } catch (err) {}
+      }
+    });
+    viewport.addEventListener('pointermove', function (e) {
+      if (!dragging) return;
+      var dx = e.clientX - lastX;
+      var dy = e.clientY - lastY;
+      if (Math.abs(dx) > 2 || Math.abs(dy) > 2) moved = true;
+      state.x += dx;
+      state.y += dy;
+      lastX = e.clientX;
+      lastY = e.clientY;
+      apply();
+    });
+    ['pointerup', 'pointercancel', 'pointerleave'].forEach(function (ev) {
+      viewport.addEventListener(ev, function () {
+        dragging = false;
+        viewport.classList.remove('grabbing');
+      });
+    });
+    // Suppress accidental link/click activation inside the diagram after a drag.
+    viewport.addEventListener('click', function (e) {
+      if (moved) { e.preventDefault(); e.stopPropagation(); }
+    }, true);
+
+    frame.querySelectorAll('.diagram-toolbar button').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var action = btn.getAttribute('data-zoom');
+        if (action === 'in') zoomBy(1.25);
+        else if (action === 'out') zoomBy(1 / 1.25);
+        else reset();
+      });
+    });
+
+    frame.dataset.pzInit = '1';
+  }
+
+  function initAll() {
+    document.querySelectorAll('.diagram-frame').forEach(initFrame);
+  }
+
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    initAll();
+  } else {
+    document.addEventListener('DOMContentLoaded', initAll);
+  }
+  window.addEventListener('load', initAll);
+})();
+</script>

--- a/scripts/render-module-graph.py
+++ b/scripts/render-module-graph.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""
+render-module-graph.py — Layer 4 of the module-integration-map pipeline.
+
+Merges Layer 1+2 (generate-module-graph.py's JSON: composition structure +
+modules-main.md metadata) with Layer 3 (module-graph-annotations.yaml:
+curated status/requires/conflict/disambiguation data) and emits the
+Mermaid diagram blocks the artifact needs: one system map plus one per
+family, however many families FAMILY_CONFIG declares.
+
+Node ids are UPPER_SNAKE, mechanically derived from the slug (same rule as
+the vendored skill's node_id()) -- never from prose, so a text sweep can't
+silently break a diagram by substituting into an id.
+
+Colour follows the skill's own rule (references/palettes.md): colour
+encodes exactly one distinction. Here that's family membership, using the
+Okabe-Ito colourblind-safe palette. Status (unsupported / shelved) is
+carried by a dashed border, not a second hue on the same node -- mixing
+the two was a real mistake in this map's first hand-built version.
+
+Usage:
+    python3 scripts/render-module-graph.py --out-dir tmp/mermaid-blocks/
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+HERE = Path(__file__).parent
+
+# Okabe-Ito, from .claude/skills/mermaid-diagrams/references/palettes.md.
+# One hue per family -- the single distinction colour is allowed to encode
+# here (references/palettes.md: "colour encodes exactly one distinction").
+# Status (unsupported/shelved) is a dashed border, never a hue.
+#
+# Assigned by position, not by family name, so this script carries zero
+# knowledge of which families exist in any given repo -- that's entirely
+# generate-module-graph.py's FAMILY_CONFIG. Six families is the practical
+# ceiling: past that, a diagram is asking for hue as a second distinction
+# anyway (see the skill's own "if you need more than three shades" note).
+OKABE_ITO_ORDER = [
+    {"fill": "#f2e6f2", "stroke": "#CC79A7", "text": "#5c2a4a"},  # purple
+    {"fill": "#fbe8dc", "stroke": "#D55E00", "text": "#7a2d00"},  # orange
+    {"fill": "#def5ee", "stroke": "#009E73", "text": "#00402e"},  # green
+    {"fill": "#e3f0f8", "stroke": "#0072B2", "text": "#063a57"},  # blue
+    {"fill": "#fdf3d9", "stroke": "#E69F00", "text": "#6b4a00"},  # yellow
+    {"fill": "#f1efe8", "stroke": "#5f5e5a", "text": "#2c2c2a"},  # neutral
+]
+EXTERNAL_STYLE = {"fill": "none", "stroke": "#5f5e5a", "text": "#5f5e5a"}  # neutral, dashed
+
+
+def family_palette(family_names) -> dict:
+    ordered = sorted(family_names)
+    if len(ordered) > len(OKABE_ITO_ORDER):
+        sys.exit(
+            f"{len(ordered)} families but only {len(OKABE_ITO_ORDER)} "
+            "colourblind-safe hues -- that many families in one map is "
+            "asking hue to carry a second distinction; split the map "
+            "instead of adding a seventh colour."
+        )
+    return dict(zip(ordered, OKABE_ITO_ORDER))
+
+
+def node_id(slug: str) -> str:
+    return re.sub(r"[^A-Za-z0-9]", "_", slug).upper()
+
+
+def run_generator(repo: Path) -> dict:
+    out = subprocess.run(
+        [sys.executable, str(HERE / "generate-module-graph.py")],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+    if out.returncode != 0:
+        sys.exit(f"generate-module-graph.py failed:\n{out.stderr}")
+    return json.loads(out.stdout)
+
+
+def load_annotations() -> dict:
+    return yaml.safe_load((HERE / "module-graph-annotations.yaml").read_text())
+
+
+def title_for(slug: str, modules: dict, overrides: dict) -> str:
+    if slug in overrides:
+        return overrides[slug]
+    return modules.get(slug, {}).get("title", slug)
+
+
+class FamilyDiagram:
+    """One family's flowchart -- its own members, plus any external node
+    pulled in only because a requires/extra/conflict edge points at it."""
+
+    def __init__(self, family_name: str, members: set, report: dict, ann: dict, palette: dict):
+        self.family = family_name
+        self.members = set(members)
+        self.external = set()
+        self.report = report
+        self.ann = ann
+        self.modules = report["modules"]
+        self.palette = palette
+        self.lines = []
+
+    def _label(self, slug: str) -> str:
+        return title_for(slug, self.modules, self.ann["title_overrides"]).replace('"', "'")
+
+    def _touch_external(self, slug: str):
+        if slug not in self.members and slug in self.modules:
+            self.external.add(slug)
+
+    def composition_edges(self):
+        overrides = {(e["from"], e["to"]): e["status"] for e in self.ann["edge_status"]}
+        edges = []
+        for slug in sorted(self.members):
+            for c in self.modules.get(slug, {}).get("constituents", []):
+                if c not in self.members:
+                    continue
+                status = overrides.get((c, slug), "confirmed")
+                arrow = "-.->" if status == "proposed" else "-->"
+                edges.append(f"    {node_id(c)} {arrow} {node_id(slug)}")
+        return edges
+
+    def requires_edges(self):
+        """Only edges whose declared `family` is this one. Membership
+        alone would double-count: a module can be a real member of more
+        than one family (base-cytosol is required by PURExpress modules
+        but lives in the Shared family), and inferring from "either side
+        is a member" pulled unrelated edges into diagrams that had
+        nothing to do with them."""
+        edges = []
+        for r in self.ann["requires"]:
+            if r["family"] != self.family:
+                continue
+            left, right = r["left"], r["right"]
+            self._touch_external(left)
+            self._touch_external(right)
+            edges.append(f'    {node_id(right)} -.->|requires| {node_id(left)}')
+        return edges
+
+    def extra_edges(self):
+        edges = []
+        for e in self.ann["extra_edges"]:
+            if e["family"] != self.family:
+                continue
+            self._touch_external(e["from"])
+            self._touch_external(e["to"])
+            style = e["style"]
+            label = e["label"]
+            if style == "implementation":
+                edges.append(
+                    f'    {node_id(e["from"])} =="{label}"==> {node_id(e["to"])}'
+                )
+            else:  # substitute, assay -- both read as a soft dotted claim
+                edges.append(
+                    f'    {node_id(e["from"])} -. "{label}" .-> {node_id(e["to"])}'
+                )
+        return edges
+
+    def conflict_edges(self):
+        edges = []
+        for c in self.ann["conflicts"]:
+            if c["family"] != self.family:
+                continue
+            self._touch_external(c["a"])
+            self._touch_external(c["b"])
+            edges.append(f'    {node_id(c["a"])} --x|"{c["label"]}"| {node_id(c["b"])}')
+        return edges
+
+    def render(self, direction="TD") -> str:
+        comp = self.composition_edges()
+        req = self.requires_edges()
+        extra = self.extra_edges()
+        conf = self.conflict_edges()
+
+        lines = [
+            "```mermaid",
+            "%%{init: {'theme': 'base', 'themeVariables': "
+            "{'lineColor': '#555555', 'edgeLabelBackground': '#ffffff'}}}%%",
+            f"flowchart {direction}",
+        ]
+        for slug in sorted(self.members):
+            lines.append(f'    {node_id(slug)}["{self._label(slug)}"]')
+        for slug in sorted(self.external):
+            lines.append(f'    {node_id(slug)}(("{self._label(slug)}"))')
+        lines.append("")
+        lines += comp + req + extra + conf
+        lines.append("")
+
+        pal = self.palette[self.family]
+        lines.append(
+            f'    classDef fam fill:{pal["fill"]},stroke:{pal["stroke"]},color:{pal["text"]};'
+        )
+        lines.append(
+            f'    classDef ext fill:{EXTERNAL_STYLE["fill"]},'
+            f'stroke:{EXTERNAL_STYLE["stroke"]},color:{EXTERNAL_STYLE["text"]},'
+            f'stroke-dasharray:5 5;'
+        )
+        if self.members:
+            lines.append("    class " + ",".join(node_id(s) for s in sorted(self.members)) + " fam;")
+        if self.external:
+            lines.append("    class " + ",".join(node_id(s) for s in sorted(self.external)) + " ext;")
+
+        # Status: a dashed border on top of the family fill -- never a
+        # second hue on the same node (see references/palettes.md).
+        node_status = self.ann["node_status"]
+        for slug in sorted(self.members | self.external):
+            if slug in node_status:
+                lines.append(f"    style {node_id(slug)} stroke-dasharray: 4 3")
+
+        lines.append("```")
+        return "\n".join(lines)
+
+
+def render_system_map(report: dict, ann: dict, palette: dict) -> str:
+    families = list(report["families"].keys())
+    counts = {f: len(report["families"][f]["members"]) for f in families}
+    lines = [
+        "```mermaid",
+        "%%{init: {'theme': 'base', 'themeVariables': "
+        "{'lineColor': '#555555', 'edgeLabelBackground': '#ffffff'}}}%%",
+        "flowchart LR",
+    ]
+    for f in families:
+        name = report["families"][f]["display_name"]
+        lines.append(f'    {f.upper()}["{name} &mdash; {counts[f]} module(s)"]')
+    lines.append("")
+    for e in ann["system_map_edges"]:
+        lines.append(f'    {e["from"].upper()} -- "{e["label"]}" --> {e["to"].upper()}')
+    lines.append("")
+    for f in families:
+        pal = palette[f]
+        lines.append(
+            f'    classDef {f} fill:{pal["fill"]},stroke:{pal["stroke"]},color:{pal["text"]};'
+        )
+        lines.append(f"    class {f.upper()} {f};")
+    lines.append("```")
+    return "\n".join(lines)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out-dir", type=Path, default=Path("tmp/mermaid-blocks"))
+    ap.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(
+            subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True
+            ).stdout.strip()
+            or "."
+        ),
+    )
+    args = ap.parse_args()
+
+    report = run_generator(args.repo_root)
+    ann = load_annotations()
+    palette = family_palette(report["families"].keys())
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    (args.out_dir / "system-map.md").write_text(render_system_map(report, ann, palette) + "\n")
+
+    for family, data in report["families"].items():
+        direction = data.get("direction", "TD")
+        diagram = FamilyDiagram(family, set(data["members"]), report, ann, palette)
+        text = diagram.render(direction)
+        (args.out_dir / f"{family}.md").write_text(text + "\n")
+        print(f"{family}: {len(diagram.members)} member(s), {len(diagram.external)} external ref(s)")
+
+    print(f"\nwritten to {args.out_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a four-layer, independently-regenerable pipeline that produces the module-integration-map: a page showing how every module under `docs/modules/` composes and depends on the others.

- **Layer 1** (not mine): composition structure, parsed the same way the (not yet merged) [nucleus-eng/nucleus-skills#6](https://github.com/nucleus-eng/nucleus-skills/pull/6) `mermaid-diagrams` skill reads it — bullet-list links under a page's own `# Constituent Modules` section. The skill is vendored into `.claude/skills/mermaid-diagrams/` (see its `PROVENANCE.md` for exactly what and when to delete once the marketplace plugin loads it live).
- **Layer 2** (`generate-module-graph.py`): merges in module class + validation stars from `modules-main.md`, and resolves family membership — either a real composition closure from a declared root, or a declared flat list for the two pages (Base Cell, Dye Liposomes) that are genuinely composed of other modules but don't have a machine-readable `# Constituent Modules` section yet.
- **Layer 3** (`module-graph-annotations.yaml`): the curated layer — anything that required reading prose rather than parsing structure (the aHly→Cx43 substitution claim, the tetR-aTc/IV-HSL implementation-only pairing, ClpXP's borrowed deGFP readout). Each entry declares which family's diagram it belongs to explicitly, rather than being inferred from node membership.
- **Layer 4** (`render-module-graph.py` + `assemble-module-graph-artifact.py`): renders the Mermaid diagrams (colour encodes exactly one distinction — family — via the skill's own Okabe-Ito colourblind-safe palette, assigned dynamically so the script has zero hardcoded family names) and substitutes them into `module-graph-template.html`'s placeholders.

This PR is scoped to `main`'s current 12 modules only — it doesn't reference or depend on any other in-flight content branch, so it can merge independently of the content PRs currently in review.

## Test plan

- [x] `python3 scripts/generate-module-graph.py` — all 12 modules found, both families resolve with no warnings
- [x] `python3 scripts/render-module-graph.py --out-dir tmp/mermaid-blocks` — emits system-map, shared, purex diagrams; verified composition/requires/substitute/implementation edges match the source pages
- [x] `python3 scripts/assemble-module-graph-artifact.py --out module-graph.html` — produces the full page
- [x] Published the assembled output and visually confirmed the diagrams (system map, both family panels, dashed status border on the unsupported α-Hemolysin node)
- [ ] Reviewer: run the three commands above locally and eyeball `module-graph.html` in a browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)