### PR TITLE
Run the composition-tab check in CI, and fix two holes in it

### DIFF
--- a/.claude/skills/nucleus-style/SKILL.md
+++ b/.claude/skills/nucleus-style/SKILL.md
@@ -21,11 +21,16 @@ In this order. The first step finds what is *missing*, which a read-through cann
 ### 1. Completeness — run the checks first
 
 ```bash
-python3 scripts/check-composition-tabs.py docs/modules/<name>/
+python3 scripts/check-composition-tabs.py docs/modules/<name>/   # scoped, fast loop
+python3 scripts/check-composition-tabs.py                        # whole corpus
 python3 scripts/check-implementations.py
 ```
 
-These enumerate from the dependency graph, so they are complete in a way no prose check can be. A page can read perfectly and still be missing half its composition.
+Both run in CI on every pull request, so the local run is for speed, not for safety. Run the scoped form while editing one page, and the unscoped form before you finish: **a scoped run only ever sees its own directory.** A Module spec named `<name>-spec.md` rather than `<name>/spec.md` is invisible to the glob, and the check reports it — but only if the run covers the directory it is in.
+
+These enumerate from the dependency graph, and that is the whole reason to run them first. The constituent relation is transitive, so the full closure of a Module is derivable from the pages — a tool can compute the list of things that *should* be on the page and compare. Prose review cannot do this. Reading inspects what is present, and **absence has no textual signature**: a page missing half its composition reads exactly like a page whose composition is short. No amount of care recovers what was never written down.
+
+That asymmetry is why the order in this section is fixed. Step 1 finds what is missing, by enumeration. Steps 2 to 4 find what is present and wrong, by reading. Doing them the other way round means a careful pass over an incomplete page.
 
 Then by hand, against [`sections.md`](../../../style-guide/sections.md):
 
@@ -74,4 +79,14 @@ Run the pre-PR list in [`conventions.md`](../../../style-guide/conventions.md#be
 
 **Verify token by token.** Diff every number, temperature, construct name and cross-link against the pre-edit file. Reading the diff is not enough: a rewrite that drops a citation can drop a real value in the same sentence, and that is how the PEG hydrogel composition was lost on reporter-lacz.
 
-**Never touch** the `# Constituent Modules` heading or mermaid `classDef constituent` — the diagram generator matches both with hardcoded strings, and a page missing either drops out of the generator silently.
+**The `# Constituent Modules` heading text is load-bearing.** The diagram generator finds the section by its exact words, at any heading depth, so rewording the heading drops the page's constituents out of the graph. Rename anything else on the page freely.
+
+The mermaid `classDef constituent` line is different: the generator *writes* it and never reads it. It is output. Editing it changes the rendered colors and nothing else, and the next run overwrites it.
+
+**Do not rely on being careful about either.** Once the generator lands (it is on PR #222, not on this branch yet), verify instead:
+
+```bash
+python3 .claude/skills/mermaid-diagrams/scripts/gen-module-diagrams.py --check
+```
+
+It names every page whose block is stale or missing, which is what "silently" used to mean here. A rule that asks an author to remember something is a rule the tool should be enforcing — if you find a way to break the graph that `--check` does not report, fix the generator rather than adding a warning back here.

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -59,3 +59,21 @@ jobs:
 
       - name: Check TOC
         run: python3 scripts/check-toc.py
+
+  composition-tabs:
+    # A Module's Reference Composition must cover everything its own dependency
+    # graph contains. Absence is a claim — a page with no Membrane tab reads as
+    # "this Module has no membrane", not "we did not write it down". Checks the
+    # pages carrying a generated composition diagram, and names any Module page
+    # it cannot reach so the count never overstates its coverage. A page may
+    # waive a tab with an HTML comment. See scripts/check-composition-tabs.py.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Check composition tabs
+        run: python3 scripts/check-composition-tabs.py

--- a/scripts/check-composition-tabs.py
+++ b/scripts/check-composition-tabs.py
@@ -55,6 +55,31 @@ IMPLIES = [
 WAIVER = re.compile(r"<!--\s*composition-tabs:\s*no-([a-z]+)\b", re.I)
 
 
+HEADING = re.compile(r"^(#{1,6})[ \t]+(.+?)[ \t]*$", re.M)
+
+
+def section_bodies(text: str, title: str) -> list[str]:
+    """Bodies under every heading named `title`, at whatever depth.
+
+    Each body ends at the next heading of the same or shallower depth. Pages
+    carry this section at H1, H2 or H3 depending on template, and a page with
+    both a Cytosols and a Cells arm carries two of them.
+    """
+    out = []
+    for m in HEADING.finditer(text):
+        if m.group(2).strip() != title:
+            continue
+        depth = len(m.group(1))
+        rest = text[m.end():]
+        end = len(rest)
+        for n in HEADING.finditer(rest):
+            if len(n.group(1)) <= depth:
+                end = n.start()
+                break
+        out.append(rest[:end])
+    return out
+
+
 def diagram_nodes(text: str) -> set[str]:
     """Node ids declared inside the generated block."""
     if BEGIN not in text or END not in text:
@@ -74,12 +99,14 @@ def composition_surface(text: str) -> str:
     requirement by carrying a captioned membrane table, so matching tab titles
     alone reports a false gap. This searches the whole section instead.
     """
-    if "# Reference Composition" not in text:
+    sections = section_bodies(text, "Reference Composition")
+    if not sections:
         return " | ".join(tab_titles(text))
-    section = text.split("# Reference Composition", 1)[1].split("\n# ", 1)[0]
-    parts = re.findall(r"^:*\{tab-item\}\s*(.+?)\s*$", section, re.M)
-    parts += re.findall(r"^:*\{table\}\s*(.+?)\s*$", section, re.M)
-    parts += re.findall(r"^:(?:label|name):\s*(\S+)\s*$", section, re.M)
+    parts = []
+    for section in sections:
+        parts += re.findall(r"^:*\{tab-item\}\s*(.+?)\s*$", section, re.M)
+        parts += re.findall(r"^:*\{table\}\s*(.+?)\s*$", section, re.M)
+        parts += re.findall(r"^:(?:label|name):\s*(\S+)\s*$", section, re.M)
     return " | ".join(parts)
 
 
@@ -91,8 +118,8 @@ def check(path: Path) -> tuple[list[str], list[str]]:
     # A composition tab should carry a table. A Module that genuinely takes
     # several hosts is the exception, so this warns rather than fails.
     advisories = []
-    if "# Reference Composition" in text and "table" not in waived:
-        sec = text.split("# Reference Composition", 1)[1].split("\n# ", 1)[0]
+    if "table" not in waived:
+        sec = "\n".join(section_bodies(text, "Reference Composition"))
         for blk in re.split(r"^:*\{tab-item\} ", sec, flags=re.M)[1:]:
             title = blk.split("\n", 1)[0].strip()
             if title in ("Module Dependencies", "Schematic"):
@@ -127,12 +154,33 @@ def check(path: Path) -> tuple[list[str], list[str]]:
     return findings, advisories
 
 
+def unreachable_specs(targets: list[Path]) -> list[Path]:
+    """Module pages this script cannot see, because they are misnamed.
+
+    `style-guide/page-types.md` puts a Module spec at `docs/modules/<name>/spec.md`.
+    A page named `<name>-spec.md` is still a spec to a reader, but it is invisible
+    to the glob below — so the run would report success over a corpus it never
+    looked at. Silently checking fewer pages than exist is the one failure a
+    checker must not have.
+    """
+    return sorted(
+        {
+            s
+            for t in targets
+            if not t.is_file()
+            for s in t.rglob("*spec.md")
+            if s.name != "spec.md"
+        }
+    )
+
+
 def main() -> int:
     targets = [Path(a) for a in sys.argv[1:]] or [MODULES_ROOT]
     specs = sorted(
         {s for t in targets for s in ([t] if t.is_file() else t.rglob("spec.md"))}
     )
-    if not specs:
+    unreachable = unreachable_specs(targets)
+    if not specs and not unreachable:
         print("error: no spec.md found in the given path(s)", file=sys.stderr)
         return 2
 
@@ -146,14 +194,27 @@ def main() -> int:
     for a in advisories:
         print(f"warning: {a}")
 
-    if findings:
-        for f in findings:
-            print(f"error: {f}")
-        pages = len({f.split(':')[0] for f in findings})
+    for u in unreachable:
         print(
-            f"\n{len(findings)} missing tab(s) across {pages} page(s). "
-            "A tab may say the composition is not documented; it may not be absent."
+            f"error: {u}: a Module spec lives at <name>/spec.md, so nothing "
+            "checks this page — rename it or move it into its own directory"
         )
+
+    for f in findings:
+        print(f"error: {f}")
+
+    summary = []
+    if findings:
+        pages = len({f.split(":")[0] for f in findings})
+        summary.append(
+            f"{len(findings)} missing tab(s) across {pages} page(s) — a tab may "
+            "say the composition is not documented; it may not be absent"
+        )
+    if unreachable:
+        summary.append(f"{len(unreachable)} Module page(s) the check cannot reach")
+
+    if summary:
+        print("\n" + ". ".join(summary) + ".")
         return 1
 
     note = f" {len(advisories)} advisory." if advisories else ""


### PR DESCRIPTION
`check-composition-tabs.py` was written on this branch and wired into no workflow, so nothing has been enforcing it. It is stdlib-only and repo-local, so it slots into `qa.yml` beside the checks it resembles.

It targets this branch rather than `main` on purpose. The check reads a generated dependency block, and the twelve pages that carry one are all here — on `main` it reports `0 page(s) checked`, which is a green tick over nothing.

## Two defects, both found by running it over a wider corpus than it was written against

**The section split was matching too much.** It found its section by the bare string `# Reference Composition`, which also matches the `##` and `###` forms, while the terminator only recognized an H1. On a page whose composition sits under `## Cytosols`, the section ran to the end of the file and pulled in the data tabs below it — six false advisories on `reporter-degfp` as it stands on `main`.

Sections are now found by anchored heading match at any depth and end at the next heading of the same or shallower depth. A page with both a Cytosols arm and a Cells arm contributes both.

**It was under-covering and reporting success.** The script collects `spec.md` and prints how many pages it checked. A page named `<name>-spec.md` is a spec to every reader and invisible to that glob. On a tree carrying both conventions, thirteen pages had a dependency diagram, twelve were checked, and the count said nothing about the thirteenth.

`style-guide/page-types.md` puts a Module spec at `docs/modules/<name>/spec.md`, so the glob is right and the filename is wrong. Rather than widen the glob and bless a second convention, the script now names any `*spec.md` that is not `spec.md` and fails. Silently checking fewer pages than exist is the one failure a checker must not have — a green tick over an unexamined corpus is read as coverage.

## nucleus-style is updated to match

Three corrections, so the skill stays true of the tools it points at:

- The scoped and unscoped runs now answer different questions, because a scoped run only ever sees its own directory.
- `classDef constituent` is written by the generator and never read. It is output, and safe to edit — the previous rule said never to touch it.
- The `# Constituent Modules` heading is matched at any depth, not by a hardcoded string, though its wording is still load-bearing.
- Its warning that a page "drops out of the generator silently" is replaced by the command that reports them.

The general form, which is the same lesson as the coverage fix above: a rule that asks an author to remember something is a rule the tool should be enforcing.

## Verified

`check-composition-tabs.py` clean over the twelve pages here, and mutation-tested — renaming a Membrane tab on a page with a `MEMBRANE_POPC` dependency still fails the check. `qa.yml` parses; the new job is copied from `file-placement` beside it.

## Not in this PR

`check-implementations.py`, the `check-links.py` anchor-fragment work, and the weekly DNA sweep all apply to `main` as it stands and are going there separately, so this PR stays orthogonal to that one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)