### PR TITLE
Check that a published page is linked from its section hub

### DIFF
--- a/scripts/check-toc.py
+++ b/scripts/check-toc.py
@@ -11,6 +11,13 @@ Two checks:
   TOC. Files excluded by naming convention (protocol-*.md, bom-*.md) or by an
   inline allowlist of known intentional non-sidebar pages are skipped.
 
+  HUB (error, exit 1): every page in the TOC must also be linked from its
+  section's hub page — docs/modules/modules-main.md and its siblings. Adding a
+  page is two table-of-contents updates, not one, and only the myst.yml half
+  was ever checked. CLAUDE.md states the duty for Modules; Processes and
+  Implementations have identical hub pages and no stated rule, and drifted the
+  same way, so this checks all three.
+
 hidden: true entries ARE real TOC entries — their files must exist.
 title:-only nodes (no file: key) are skipped.
 
@@ -19,6 +26,7 @@ Usage:
     python3 scripts/check-toc.py myst.yml
 """
 
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -76,6 +84,55 @@ def advisory_excluded(path: Path) -> bool:
     return False
 
 
+LINK_RE = re.compile(r"\]\(([^)#]+?\.md)(?:#[^)]*)?\)")
+
+# Section roots that carry a hub page listing their content pages.
+HUB_SECTIONS = ("modules", "processes", "implementations")
+
+# Pages in the TOC with no hub row. Paths from repo root.
+#
+# These two are the pre-existing debt this check was written to find, not
+# exemptions — both already have a hub row on docs/devcells-integration-pages.
+# DELETE BOTH ENTRIES when that branch merges; the check then has an empty
+# allowlist and enforces for everything.
+HUB_ALLOWLIST: set[str] = {
+    "docs/modules/detector-laci_iptg/spec.md",
+    "docs/implementations/emitter-ivhsl/main.md",
+}
+
+
+def hub_linked(hub: Path) -> set[Path]:
+    """Every .md a hub page links to, resolved."""
+    if not hub.exists():
+        return set()
+    text = hub.read_text(encoding="utf-8")
+    return {(hub.parent / raw).resolve() for raw in LINK_RE.findall(text)}
+
+
+def check_hubs(toc_resolved: set[Path]) -> list[str]:
+    """TOC pages whose section hub does not link them."""
+    findings = []
+    for section in HUB_SECTIONS:
+        root = DOCS_ROOT / section
+        hub = root / f"{section}-main.md"
+        if not hub.exists():
+            continue
+        linked = hub_linked(hub)
+        for page in sorted(root.glob("*/*.md")):
+            if page.name.startswith(ADVISORY_EXCLUDE_PREFIXES):
+                continue
+            if str(page).replace("\\", "/") in HUB_ALLOWLIST:
+                continue
+            if page.resolve() not in toc_resolved:
+                continue  # not published; myst.yml is the gate for that
+            if page.resolve() not in linked:
+                findings.append(
+                    f"{page}: in myst.yml but not linked from {hub} — "
+                    "adding a page is two TOC updates, not one"
+                )
+    return findings
+
+
 def main() -> int:
     myst_path = Path(sys.argv[1]) if len(sys.argv) > 1 else MYST_YML
     if not myst_path.exists():
@@ -105,6 +162,11 @@ def main() -> int:
         print(f"\n{strict_errors} broken TOC reference(s). Fix myst.yml.")
         return 1
 
+    # --- HUB: every published page must be linked from its section hub ---
+    hub_findings = check_hubs(toc_resolved)
+    for f in hub_findings:
+        print(f"error: {f}")
+
     # --- ADVISORY: every docs/ .md should appear in the TOC ---
     advisory_warnings = 0
     try:
@@ -130,8 +192,16 @@ def main() -> int:
 
     if advisory_warnings:
         print(f"\n{advisory_warnings} advisory: file(s) not in TOC. Add to myst.yml or allowlist.")
-    else:
-        print(f"✅ TOC valid. {len(toc_entries)} entries checked, {len(all_docs_md)} docs/ files scanned.")
+
+    if hub_findings:
+        pages = len({f.split(":")[0] for f in hub_findings})
+        print(f"\n{len(hub_findings)} page(s) missing a hub row, across {pages} file(s).")
+        return 1
+
+    if not advisory_warnings:
+        print(f"✅ TOC valid. {len(toc_entries)} entries checked, "
+              f"{len(all_docs_md)} docs/ files scanned, "
+              f"{len(HUB_SECTIONS)} hub page(s) cross-checked.")
 
     return 0  # Advisory warnings do not fail CI
 


### PR DESCRIPTION
Adding a page is two table-of-contents updates, not one — `myst.yml` and the section's hub page. Only the `myst.yml` half was ever checked, so the hub half drifted. `check-toc.py` had no reference to any hub page at all.

`CLAUDE.md` states the duty for Modules. Processes and Implementations have identical hub pages and no stated rule — and drifted the same way — so this checks all three rather than only the one the prose names.

## What it checks

Every page in the `myst.yml` TOC must be linked from `docs/<section>/<section>-main.md`.

It compares against the **TOC**, not the file tree. A page not in `myst.yml` is unpublished, and `myst.yml` is already the gate for that. So a draft sitting in the tree does not trip this, and a page trips it the moment it is published — which is the point at which the hub row starts mattering to a reader.

## Two pages on `main` have no hub row

```
docs/modules/detector-laci_iptg/spec.md
docs/implementations/emitter-ivhsl/main.md
```

Both are real — `git show origin/main:docs/modules/modules-main.md | grep -i laci` returns nothing.

They are seeded into `HUB_ALLOWLIST` as **declared debt, not exemptions**, with a note to delete both entries when `docs/devcells-integration-pages` merges — both already have a hub row there. Fixing the content pages here would put a docs edit in a tooling change, and the intended steady state is an empty allowlist.

## Verified

| | |
| --- | --- |
| `main` | green — 59 TOC entries, 38 files, 3 hubs |
| `docs/devcells-integration-pages` | green — 87 TOC entries, 66 files, 3 hubs |
| allowlist emptied against DevCells | fires on the one page still missing there, as intended |
| mutation test | removing a single hub link fails the check and names the page |

## Why a checker rather than a style rule

The duty was already written down for Modules, in prose, and `modules-main.md` drifted anyway. Prose stated the rule and did not hold it. That is the general form: **a rule that asks an author to remember something is a rule the tool should be enforcing.**

Found by the DevStudio conformance pass, which hit it twice — once on a page that session had just added, following the only rule that existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
