### PR TITLE
Catch anchors that MyST resolves to the wrong page

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -15,6 +15,13 @@ on:
 #     unrelated PR.
 #   * Vendor noise (403/429/5xx/timeout/TLS/HTTP-2 reset) never blocks anything.
 #     See issues #193 and #199.
+#
+# check-anchors.py runs in the same job because it is the same failure domain,
+# and it is the one internal-link failure check-links.py cannot see: MyST binds
+# a link fragment by global identifier and ignores the file path, so an #anchor
+# whose slug is not unique silently resolves to a different page. The file
+# exists and does own the heading, so lychee passes it. See
+# style-guide/conventions.md, Cross-references.
 jobs:
   check-links:
     runs-on: ubuntu-latest
@@ -42,3 +49,16 @@ jobs:
           python3 scripts/check-links.py \
             --blame-changed "origin/${{ github.base_ref }}" \
             docs/
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install pyyaml
+        run: pip install pyyaml
+
+      # Every page in the TOC, not just docs/ — a colliding identifier anywhere
+      # in the site can capture an anchor written in docs/. Blocks regardless of
+      # which files the PR touched, like every other internal-link failure.
+      - name: Check anchors
+        run: python3 scripts/check-anchors.py

--- a/guides/devnote-tutorial.md
+++ b/guides/devnote-tutorial.md
@@ -33,22 +33,22 @@ If you do not have these things please see the [Tutorial: getting started with N
 - [ ] Preview your DevNote.
   - [ ] In your file directory, navigate to the directory `/devnotes/template`.
   - [ ] While you're in the `devnotes/template` directory, click the button "Preview" in the "Developer Notes" toolbar of the Launcher window.
-  - [ ] You will likely see an [error message](#fig:error). That's ok.
+  - [ ] You will likely see an [error message](#fig:devnote-tutorial-error). That's ok.
   - [ ] Open the file `main.md` in your directory
-  - [ ] Create a [split screen](#fig:splitscreen) by dragging the "Preview" tab to the right corner of the screen.
+  - [ ] Create a [split screen](#fig:devnote-tutorial-splitscreen) by dragging the "Preview" tab to the right corner of the screen.
   - [ ] Make an edit, say to the level 1 heading, e.g. `#Background - edited`. The preview window should automatically refresh and you should now be able to preview any updates to your DevNote in realtime.
 
 :::::{tab-set}
 
 ::::{tab-item} Error message
 :::{figure} ./developer-notes/res-tutorial/error-loading-preview.png
-:name: fig:error
+:name: fig:devnote-tutorial-error
 :::
 ::::
 
 ::::{tab-item} Splitscreen
 :::{figure} ./developer-notes/res-tutorial/splitscreen.png
-:name: fig:splitscreen
+:name: fig:devnote-tutorial-splitscreen
 :::
 ::::
 

--- a/guides/kinetics-tutorial/main.md
+++ b/guides/kinetics-tutorial/main.md
@@ -16,7 +16,7 @@ The companion notebook `platereader.ipynb` runs the same code without the explan
 
 ## Table of Contents
 1. [Setup](#setup)
-2. [Load Data](#load-data)
+2. [Load Data](#kinetics-tutorial-load-data)
 3. [Plot Raw Curves](#plot-curves)
 4. [Normalize Data](#normalize)
 5. [Kinetic Analysis](#kinetic-analysis)
@@ -54,6 +54,7 @@ from cdk.instruments import platereader as pr
 
 ---
 
+(kinetics-tutorial-load-data)=
 ## 2. Load Data
 
 Load your plate reader output and merge it with the platemap (see [DevNote](https://devnotes.nucleus.engineering/articles/Bhasin-20260421)) that describes your experimental conditions.

--- a/scripts/check-anchors.py
+++ b/scripts/check-anchors.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""check-anchors.py — flag `#anchor` links that MyST will bind to the wrong page.
+
+MyST resolves a link fragment by *global identifier* and ignores the file path.
+Every module spec has headings called Overview, Requirements, Expected Behavior,
+so those slugs collide across pages, and MyST binds each to whichever page won.
+The reader lands somewhere else entirely — `../reporter-xyle/spec.md#expected-behavior`
+went to the POPC/Chol membrane spec, and one page's own `[Overview](#overview)`
+left `docs/` for a getting-started page.
+
+`check-links.py` cannot see this: the named file exists and does own that heading,
+so the link passes. Only the collision makes it wrong. That is what this checks.
+
+The fix is a unique label above the target heading:
+
+    (reporter-lacz-requirements)=
+    # Requirements
+
+and link to `../reporter-lacz/spec.md#reporter-lacz-requirements`. A link with no
+fragment at all is also safe — it builds as a plain link and resolves by path.
+
+Reads sources only, so it runs in well under a second and needs no myst build.
+
+Usage:
+    python3 scripts/check-anchors.py            # every page in the myst.yml TOC
+    python3 scripts/check-anchors.py <file.md>  # links written in these files only
+
+Exit codes: 0 nothing blocking, 1 mis-binding anchors found, 2 could not run.
+"""
+import importlib.util
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+MYST_YML = REPO / "myst.yml"
+
+# `[text](target#fragment)` — captures the path part (may be empty) and fragment.
+LINK = re.compile(r"\]\(([^)#\s]*)#([^)\s]+)\)")
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(name, REPO / "scripts" / filename)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def toc_pages() -> list[pathlib.Path]:
+    """Every source file myst.yml publishes as a page."""
+    try:
+        import yaml
+    except ImportError:
+        print("error: pyyaml is required. Run: pip install pyyaml", file=sys.stderr)
+        raise SystemExit(2)
+    check_toc = _load("check_toc", "check-toc.py")
+    data = yaml.safe_load(MYST_YML.read_text(encoding="utf-8"))
+    toc = (data or {}).get("project", {}).get("toc") or (data or {}).get("toc")
+    if not toc:
+        print(f"error: no toc: in {MYST_YML}", file=sys.stderr)
+        raise SystemExit(2)
+    pages = []
+    for _, resolved in check_toc.collect_toc_files(toc, MYST_YML.parent):
+        for cand in (resolved, resolved.with_suffix(".md"), resolved.with_suffix(".ipynb")):
+            if cand.is_file():
+                pages.append(cand)
+                break
+    return pages
+
+
+def main() -> int:
+    links = _load("check_links", "check-links.py")
+    pages = toc_pages()
+    if not pages:
+        print("error: resolved no pages from the TOC", file=sys.stderr)
+        return 2
+
+    # identifier -> pages that define it
+    owners: dict[str, list[pathlib.Path]] = {}
+    for page in pages:
+        for anchor in links.myst_anchors(str(page)):
+            owners.setdefault(anchor, []).append(page)
+
+    if len(sys.argv) > 1:
+        targets = [pathlib.Path(a).resolve() for a in sys.argv[1:]]
+    else:
+        targets = pages
+
+    findings = []
+    for page in targets:
+        try:
+            text = page.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for lineno, line in enumerate(text.splitlines(), 1):
+            for path_part, frag in LINK.findall(line):
+                frag = frag.split("#")[0]
+                defs = owners.get(links.myst_html_id(frag), [])
+                if len(defs) > 1:
+                    named = (page.parent / path_part).resolve() if path_part else page
+                    findings.append((page, lineno, path_part, frag, named, defs))
+
+    rel = lambda p: str(p.relative_to(REPO)) if p.is_relative_to(REPO) else str(p)
+
+    if not findings:
+        print(f"✅ no ambiguous anchors. {len(targets)} page(s) checked, "
+              f"{len(owners)} identifier(s) collected.")
+        return 0
+
+    print(f"❌ {len(findings)} anchor(s) MyST will bind to the wrong page:\n")
+    for page, lineno, path_part, frag, named, defs in findings:
+        where = f"{path_part}#{frag}" if path_part else f"#{frag}"
+        print(f"  {rel(page)}:{lineno}")
+        print(f"      wrote:      {where}")
+        print(f"      meant:      {rel(named)}")
+        print(f"      but #{frag} is defined on {len(defs)} pages, so MyST picks one:")
+        for d in defs[:4]:
+            print(f"                    {rel(d)}")
+        if len(defs) > 4:
+            print(f"                    ... and {len(defs) - 4} more")
+        print()
+    print("Fix: give the target heading a unique label and link to that.\n"
+          "     (reporter-lacz-requirements)=\n"
+          "     # Requirements\n"
+          "Name labels <module-directory>-<section-slug>. A link with no fragment is\n"
+          "also safe. See style-guide/conventions.md § Cross-references.")
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except SystemExit:
+        raise
+    except Exception as exc:  # noqa: BLE001 — tooling breakage is exit 2, not a finding
+        print(f"error: {type(exc).__name__}: {exc}", file=sys.stderr)
+        sys.exit(2)


### PR DESCRIPTION
MyST resolves a link fragment by **global identifier and ignores the file path**. Every module spec has headings called Overview, Requirements, Expected Behavior — so those slugs collide across pages, and MyST binds each to whichever page won. The reader lands somewhere else entirely.

`check-links.py` cannot see this, and never will. It verifies that the named file exists and owns that heading — both stay true while MyST sends the link to a different page. The collision *is* the defect, and nothing was looking for collisions.

On `docs/devcells-integration-pages` this had accumulated **25 links resolving to the wrong page**, every one of them passing a clean link check:

| written | resolved to |
| --- | --- |
| `../reporter-xyle/spec.md#expected-behavior` | `/docs/modules/membrane-popc-chol/spec` |
| `../reporter-lacz/spec.md#requirements` | `/docs/modules/substrate-cprg-suv/spec` |
| `ph-cascade`’s own `[Overview](#overview)` | `/start/first-guide-1` |

Same-page links are affected too — MyST does not prefer the local page.

## What this adds

`scripts/check-anchors.py` collects every identifier each page defines and flags any link whose fragment is defined more than once. Sources only, no build, **under a second**. It runs inside the existing `check-links` job because it is the same failure domain, and blocks regardless of which files a PR touched, like every other internal-link failure.

It reports **ambiguity**, not current mis-binding. An anchor landing on the right page today is correct by luck; adding or reordering a page flips it. The three `guides/` links fixed here were all in exactly that state, which is why they never looked broken.

The fix pattern, for reviewers:

```
(reporter-lacz-requirements)=
# Requirements
```

then link to `../reporter-lacz/spec.md#reporter-lacz-requirements`. A link with **no** fragment is also safe — it builds as a plain link and resolves by path.

## Base branch — please read

Opened against **`ci/checkers-for-main` (#226), not `main`**, and this was not the original intent. `check-anchors.py` reuses `myst_anchors` and `myst_html_id` from `check-links.py`, and that fragment work exists only in #226 — `main` has neither it nor `tests/test_myst_slug.py`. Based off `main`, this PR could not pass its own CI.

The alternative is vendoring ~50 lines of the slug port into `check-anchors.py`. That would work standalone, but it would put a second copy of a rule that must match `myst-common` exactly next to the one #226 pins with a test — the exact silent-divergence risk that test exists to prevent. Retarget with `gh pr edit --base main` once #226 lands, or say the word and I will vendor instead.

## Verification

- Detects an injected collision and exits 1; exits 0 on a clean tree — checked both, unpiped, so no exit code was masked by `head`.
- Green on this branch: 59 pages, 287 identifiers, 0 ambiguous.
- On the DevCells branch, all 25 fixes confirmed against the **built AST**, not the source — the source is exactly what looks fine.

## Not included

Prose for `CLAUDE.md` and `style-guide/conventions.md` lands with `docs/devcells-integration-pages`, which already carries it. Duplicating it here would guarantee a conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)