### PR TITLE
Add check-requirement-discharge.py: say when a page meets its own Requirement

### DIFF
--- a/scripts/check-requirement-discharge.py
+++ b/scripts/check-requirement-discharge.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+check-requirement-discharge.py — a Requirement whose own example satisfier is
+already inside the page should say so.
+
+`# Requirements` names what a composer must supply. When a composed Module
+writes
+
+    Requires a lipid compartment for PLA1 to lyse (e.g. [Chicago Chassis](...))
+
+and the Chicago Chassis is one of its own constituents, the page is asking the
+reader for something it already contains. The reader cannot tell that from the
+text, so the Module reads as harder to use than it is — and a composition check
+reading the same line cannot tell a Requirement that was met from one that was
+dropped.
+
+Two pages already write the met case correctly, which is where the wording
+below comes from:
+
+    Requires pT7 transcription and translation (e.g. [Base Cytosol](...)),
+    supplied here by the [Chicago Chassis](...).
+
+So this check has a positive control built into the corpus: if it ever reports
+`atc-sensing-cell` or `theophylline-sensing-cell` for pT7, the matcher broke.
+
+Scope. Only `e.g.` links count as satisfiers. A `see` link is a cross-reference
+to the Module that *imposes* the constraint — `reporter-lacz` is the source of
+the LacZ/CPRG separation requirement, not a thing that meets it — and reporting
+those would be wrong. Pages that use `e.g.` where they mean `see` will show up
+here; that is also worth fixing, and the fix is the same edit.
+
+Waivers go on the page as an HTML comment naming the module and the reason:
+
+    <!-- requirement-discharge: chicago-chassis (the composer may substitute
+         their own chassis, so the requirement stays open) -->
+
+Usage:
+    python3 scripts/check-requirement-discharge.py
+    python3 scripts/check-requirement-discharge.py docs/modules/atc-cascade/
+"""
+
+import re
+import sys
+from pathlib import Path
+
+MODULES_ROOT = Path("docs/modules")
+
+SPEC_LINK = r'\]\(\.\./([a-z0-9-]+)/spec\.md'
+# "supplied here by", "as supplied by" — the page saying the requirement is met.
+DISCHARGED = re.compile(r"supplied here by|as supplied by|provided here by", re.I)
+WAIVER = re.compile(r"<!--\s*requirement-discharge:\s*([a-z0-9-]+)")
+
+
+def section(text, name):
+    m = re.search(r"^# " + name + r"\s*\n(.*?)(?=^# |\Z)", text, re.S | re.M)
+    return m.group(1) if m else ""
+
+
+def constituents(text):
+    return [m.group(1) for m in re.finditer(SPEC_LINK, section(text, "Constituent Modules"))]
+
+
+def closure(name, graph, seen=None):
+    seen = set() if seen is None else seen
+    for child in graph.get(name, []):
+        if child not in seen:
+            seen.add(child)
+            closure(child, graph, seen)
+    return seen
+
+
+def atoms(requirements):
+    """Top-level paragraphs, with admonition blocks removed."""
+    out, depth = [], 0
+    for line in requirements.split("\n"):
+        if re.match(r"^:{3,}\{", line):
+            depth += 1
+            continue
+        if re.match(r"^:{3,}\s*$", line):
+            depth = max(0, depth - 1)
+            continue
+        if depth == 0:
+            out.append(line)
+    return [p.strip() for p in "\n".join(out).split("\n\n") if p.strip()]
+
+
+def satisfiers(atom):
+    """Modules named as an example satisfier — `e.g. [X](../x/spec.md)`.
+
+    Bounded to the clause the `e.g.` opens, so a later `see [Y]` in the same
+    paragraph is not swept in.
+    """
+    found = []
+    for m in re.finditer(r"e\.g\.,?\s*", atom):
+        clause = atom[m.end():]
+        cut = re.search(r"\)\s*[.;]|\bsee\b", clause)
+        if cut:
+            clause = clause[: cut.start() + 1]
+        found += re.findall(SPEC_LINK, clause)
+    return found
+
+
+def main(argv=None):
+    argv = sys.argv[1:] if argv is None else list(argv)
+    if not MODULES_ROOT.is_dir():
+        print("error: run from the repository root", file=sys.stderr)
+        return 2
+
+    specs = {p.parent.name: p for p in MODULES_ROOT.glob("*/spec.md")}
+    if not specs:
+        print("error: no module specs found", file=sys.stderr)
+        return 2
+
+    texts = {name: path.read_text(encoding="utf-8") for name, path in specs.items()}
+    graph = {name: constituents(text) for name, text in texts.items()}
+
+    targets = sorted(specs)
+    if argv:
+        wanted = {Path(a.rstrip("/")).name for a in argv}
+        targets = [t for t in targets if t in wanted]
+        if not targets:
+            print(f"error: no module spec matched {sorted(wanted)}", file=sys.stderr)
+            return 2
+
+    findings, checked, positive_control = [], 0, 0
+    for name in targets:
+        if not graph.get(name):
+            continue  # a leaf discharges nothing
+        checked += 1
+        own = closure(name, graph)
+        waived = set(WAIVER.findall(texts[name]))
+        for atom in atoms(section(texts[name], "Requirements")):
+            inside = sorted({s for s in satisfiers(atom) if s in own} - waived)
+            if not inside:
+                continue
+            if DISCHARGED.search(atom):
+                positive_control += 1
+                continue
+            first = atom.split("\n")[0]
+            head = first if len(first) <= 90 else first[:87] + "..."
+            findings.append(
+                f"{name}: requires something its own {', '.join(inside)} supplies, "
+                f"but does not say so\n         {head}"
+            )
+
+    for f in findings:
+        print(f"error: {f}")
+
+    if findings:
+        pages = len({f.split(":")[0] for f in findings})
+        print(
+            f"\n{len(findings)} undischarged Requirement(s) across {pages} page(s). "
+            'Add "supplied here by [X]", or drop the line if the composer never '
+            "supplies it."
+        )
+        return 1
+
+    if not checked:
+        # A scan that reports zero has to be shown capable of reporting non-zero.
+        # No composed Modules means the corpus this check is for is not here —
+        # on `main` today the DevCells specs are unmerged — so a green tick would
+        # be a clean number that measured nothing.
+        print(
+            "error: no composed Module pages found, so this check proved nothing. "
+            "It needs specs with both `# Constituent Modules` and `# Requirements`.",
+            file=sys.stderr,
+        )
+        return 2
+
+    note = f" {positive_control} already marked as supplied." if positive_control else ""
+    print(f"✅ No undischarged Requirements. {checked} composed page(s) checked.{note}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_requirement_discharge.py
+++ b/scripts/tests/test_check_requirement_discharge.py
@@ -1,0 +1,215 @@
+"""Tests for scripts/check-requirement-discharge.py.
+
+The motivating cases are on `docs/devcells-integration-pages`, not `main`: ten
+Requirements name an example satisfier the page already contains, while two —
+`atc-sensing-cell` and `theophylline-sensing-cell` — write the met case as
+"supplied here by the Chicago Chassis". Those two are the positive control, and
+a test locks them so a future matcher change cannot start flagging the correct
+form.
+
+The distinction the check turns on is `e.g.` against `see`. `e.g. [X]` names
+something that satisfies the requirement; `see [X]` names the Module that
+imposes it. The LacZ/CPRG separation lines link the reporter as the *source* of
+the constraint, so reporting them would be wrong.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    """Import check-requirement-discharge.py by path (hyphenated filename)."""
+    path = Path(__file__).resolve().parent.parent / "check-requirement-discharge.py"
+    spec = importlib.util.spec_from_file_location("check_requirement_discharge", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+crd = _load_module()
+
+
+def _spec(constituents=(), requirements="", extra=""):
+    out = ["---", 'title: "Test"', "---", "", "# Overview", "", "Test page.", ""]
+    if requirements:
+        out += ["# Requirements", "", requirements, ""]
+    if constituents:
+        out += ["# Constituent Modules", ""]
+        out += [f"- [{c}](../{c}/spec.md) — a part" for c in constituents]
+        out += [""]
+    if extra:
+        out += [extra, ""]
+    return "\n".join(out)
+
+
+@pytest.fixture
+def corpus(tmp_path, monkeypatch):
+    """Build a docs/modules tree and point the check at it."""
+
+    def build(pages):
+        root = tmp_path / "docs" / "modules"
+        for name, text in pages.items():
+            (root / name).mkdir(parents=True, exist_ok=True)
+            (root / name / "spec.md").write_text(text, encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(crd, "MODULES_ROOT", Path("docs/modules"))
+        return root
+
+    return build
+
+
+# --------------------------------------------------------------------------- #
+# satisfiers(): e.g. means satisfied-by, see means cross-reference
+# --------------------------------------------------------------------------- #
+
+
+def test_eg_link_is_a_satisfier():
+    atom = "Requires pT7 transcription (e.g. [Base Cytosol](../base-cytosol/spec.md))."
+    assert crd.satisfiers(atom) == ["base-cytosol"]
+
+
+def test_see_link_is_not_a_satisfier():
+    """The reporter imposes the LacZ/CPRG constraint; it does not meet it."""
+    atom = (
+        "Must not be exposed to theophylline. See "
+        "[LacZ Reporter](../reporter-lacz/spec.md) for the constraint."
+    )
+    assert crd.satisfiers(atom) == []
+
+
+def test_see_after_eg_in_one_paragraph_is_not_swept_in():
+    atom = (
+        "Requires a membrane (e.g. [POPC](../membrane-popc/spec.md)); "
+        "see [PLA1](../effector-pla1/spec.md) for why."
+    )
+    assert crd.satisfiers(atom) == ["membrane-popc"]
+
+
+def test_two_satisfiers_in_one_clause():
+    atom = (
+        "Requires transcription (e.g. [Base Cytosol](../base-cytosol/spec.md), "
+        "[S30 Lysate](../s30-lysate/spec.md))."
+    )
+    assert sorted(crd.satisfiers(atom)) == ["base-cytosol", "s30-lysate"]
+
+
+# --------------------------------------------------------------------------- #
+# atoms(): admonitions are not Requirements
+# --------------------------------------------------------------------------- #
+
+
+def test_admonition_content_is_excluded():
+    req = (
+        "Requires a membrane (e.g. [POPC](../membrane-popc/spec.md)).\n\n"
+        ":::{attention} A caveat\n"
+        "Requires something else (e.g. [Other](../other/spec.md)).\n"
+        ":::\n"
+    )
+    found = [s for a in crd.atoms(req) for s in crd.satisfiers(a)]
+    assert found == ["membrane-popc"]
+
+
+# --------------------------------------------------------------------------- #
+# End to end
+# --------------------------------------------------------------------------- #
+
+
+def test_flags_a_satisfier_inside_the_composite(corpus, capsys):
+    corpus(
+        {
+            "chassis": _spec(),
+            "cell": _spec(
+                constituents=["chassis"],
+                requirements="Requires a compartment (e.g. [Chassis](../chassis/spec.md)).",
+            ),
+        }
+    )
+    assert crd.main([]) == 1
+    assert "cell: requires something its own chassis supplies" in capsys.readouterr().out
+
+
+def test_supplied_here_by_is_not_flagged(corpus, capsys):
+    """The positive control — the form atc-sensing-cell already uses."""
+    corpus(
+        {
+            "chassis": _spec(),
+            "cell": _spec(
+                constituents=["chassis"],
+                requirements=(
+                    "Requires a compartment (e.g. [Chassis](../chassis/spec.md)), "
+                    "supplied here by the [Chassis](../chassis/spec.md)."
+                ),
+            ),
+        }
+    )
+    assert crd.main([]) == 0
+    assert "1 already marked as supplied" in capsys.readouterr().out
+
+
+def test_satisfier_outside_the_composite_is_not_flagged(corpus):
+    """A genuinely open Requirement is the normal case and must stay quiet."""
+    corpus(
+        {
+            "cytosol": _spec(),
+            "chassis": _spec(),
+            "cell": _spec(
+                constituents=["chassis"],
+                requirements="Requires transcription (e.g. [Cytosol](../cytosol/spec.md)).",
+            ),
+        }
+    )
+    assert crd.main([]) == 0
+
+
+def test_transitive_constituent_counts(corpus):
+    """cell -> chassis -> cytosol: the cytosol is inside the cell."""
+    corpus(
+        {
+            "cytosol": _spec(),
+            "chassis": _spec(constituents=["cytosol"]),
+            "cell": _spec(
+                constituents=["chassis"],
+                requirements="Requires transcription (e.g. [Cytosol](../cytosol/spec.md)).",
+            ),
+        }
+    )
+    assert crd.main([]) == 1
+
+
+def test_waiver_suppresses_the_finding(corpus):
+    corpus(
+        {
+            "chassis": _spec(),
+            "cell": _spec(
+                constituents=["chassis"],
+                requirements="Requires a compartment (e.g. [Chassis](../chassis/spec.md)).",
+                extra="<!-- requirement-discharge: chassis (composer may substitute) -->",
+            ),
+        }
+    )
+    assert crd.main([]) == 0
+
+
+def test_leaf_module_is_not_checked(corpus):
+    """A Module with no constituents discharges nothing, so it is out of scope."""
+    corpus(
+        {
+            "leaf": _spec(
+                requirements="Requires a membrane (e.g. [POPC](../membrane-popc/spec.md)).",
+            ),
+        }
+    )
+    assert crd.main([]) == 2  # nothing composed to check — see below
+
+
+def test_no_composed_pages_is_an_error_not_a_pass(corpus, capsys):
+    """A scan that reports zero must be shown capable of reporting non-zero.
+
+    `main` today has no composed Module pages, so a green tick there would be a
+    clean number that measured nothing.
+    """
+    corpus({"leaf": _spec(requirements="Requires something.")})
+    assert crd.main([]) == 2
+    assert "proved nothing" in capsys.readouterr().err


### PR DESCRIPTION
Closes part of #224's `provides` case, and supplies a measurement for #223.

## What it checks

A composed Module that writes

> Requires a lipid compartment for PLA1 to lyse (e.g. [Chicago Chassis](...))

while the Chicago Chassis is one of its own constituents is asking the reader for something it already contains. The page reads as harder to use than it is, and a composition check reading the same line cannot tell a Requirement that was **met** from one that was **dropped**.

## Why it can ship now

Two pages on `docs/devcells-integration-pages` already write the met case:

> Requires pT7 transcription and translation (e.g. Base Cytosol), **supplied here by the Chicago Chassis**.

So the corpus supplies both the wording and a positive control. Against that branch: **10 findings across 4 pages**, with those two correctly quiet. No new vocabulary, no schema, no retrofit — it reads the graph and the links that are already there.

## Scope

Only `e.g.` links count as satisfiers. A `see` link names the Module that *imposes* the constraint rather than one that meets it, so the LacZ/CPRG separation lines are correctly not reported. A page using `e.g.` where it means `see` will show up here, and the fix is the same edit either way.

Waivers go on the page:

```
<!-- requirement-discharge: chicago-chassis (composer may substitute their own) -->
```

## Note on `main`

`main` has 14 modules and **no** `# Requirements` or `# Constituent Modules` sections — the DevCells specs are unmerged. So the check exits **2** here rather than 0: a scan that reports zero has to be shown capable of reporting non-zero, and a green tick on an empty corpus would be a clean number that measured nothing.

**Not wired into a workflow by this PR** for that reason. Wire it once the content branch merges. `scripts/tests/` runs under `protocols.yml` today, so the 12 unit tests do run in CI.

## Tests

12 tests, including the positive control, the `e.g.`/`see` split, transitive constituents, waivers, and the exit-2-on-empty behaviour. Full suite: 93 passed.