### PR TITLE
Fix five links that 404 on the deployed site

### DIFF
--- a/about/release-notes/v050.md
+++ b/about/release-notes/v050.md
@@ -90,7 +90,7 @@ We have introduced the following specifications to the Docs:
 - [**Specification**](https://docs.nucleus.engineering/docs/modules/control-clpxp/spec/)
 - [**Discuss on the Forum**](https://forum.nucleus.engineering/t/clpxp-control-module/32)
 
-Going forward, our documentation (Docs) will now reside at https://docs.nucleus.engineering/. Going forward, this will be the site that is maintained and upgraded. We are actively migrating documentation from [https://nucleus.bnext.bio](https://nucleus.bnext.biohttps://nucleus.bnext.bio/) to this new site as Modules are validated in Nucleus Cytosol. 
+Going forward, our documentation (Docs) will now reside at https://docs.nucleus.engineering/. Going forward, this will be the site that is maintained and upgraded. We are actively migrating documentation from [https://nucleus.bnext.bio](https://nucleus.bnext.bio/) to this new site as Modules are validated in Nucleus Cytosol. 
 
 The new site is built with JupyterBook and MyST Markdown. This is the same tech stack underlying DevNotes and will allow for greater integration and interoperability between the two sites. 
 
@@ -103,7 +103,7 @@ The new site will also have a streamlined structure that builds on our lessons o
 
 Importantly, all documentation and protocols will be built on Nucleus Cytosol, introduced this release, enabling shared development and interoperability. 
 
-For the foreseeable future, [https://nucleus.bnext.bio](https://nucleus.bnext.biohttps://nucleus.bnext.bio/) will remain live.
+For the foreseeable future, [https://nucleus.bnext.bio](https://nucleus.bnext.bio/) will remain live.
 
 ## Hub
 

--- a/guides/developer-notes/developer-notes.md
+++ b/guides/developer-notes/developer-notes.md
@@ -17,7 +17,7 @@ Most of the DevNote tools that appear in the Launcher require setting up API acc
 - [ ]  Select ‘API Access’ and click ‘Generate New Token’.
   - [ ]  Give the token a useful description and select Expiry for the maximum time allowed.
 - [ ]  From Nucleus Hub, open a terminal window from the Launcher and run the command `curvenote token set [my-token]`
-- [ ]  You should see a message that says: Token set for "[curvenote-username]" <curvenote-email-account> at https://api.curvenote.com/login”
+- [ ]  You should see a message that says: `Token set for "[curvenote-username]" <curvenote-email-account> at https://api.curvenote.com/login`
 
 :::::{tab-set}
 

--- a/guides/kinetics-tutorial/main.md
+++ b/guides/kinetics-tutorial/main.md
@@ -2,7 +2,7 @@
 
 :::{attention}
 :class: simple
-This tutorial applies to CDK version >=0.6.0. For older versions, see the tutorial [here](guides/platereader-tutorial/).
+This tutorial applies to CDK version >=0.6.0. For older versions, see the tutorial [here](../platereader_tutorial.md).
 :::
 
 ## Overview

--- a/guides/platereader_tutorial.md
+++ b/guides/platereader_tutorial.md
@@ -2,7 +2,7 @@
 
 :::{attention}
 :class: simple
-This tutorial applies to CDK version <0.6.0. For newer versions, see the tutorial [here](guides/kinetics-tutorial/).
+This tutorial applies to CDK version <0.6.0. For newer versions, see the tutorial [here](./kinetics-tutorial/main.md).
 :::
 
 ## Overview

--- a/start/first-guide.md
+++ b/start/first-guide.md
@@ -20,7 +20,7 @@ If you are looking to get started quickly, we recommend acquiring a kit from b.n
 # Using the Distribution as a knowledge base
 
 The Distribution contains useful documentation organized across four different categories:
-- [Modules](../docs/modules/modules-main.md) include specification pages for functional biological modules (see [Nucleus Cytosol](./base-cytosol/spec) as an example). 
+- [Modules](../docs/modules/modules-main.md) include specification pages for functional biological modules (see [Nucleus Cytosol](../docs/modules/base-cytosol/spec.md) as an example). 
 - [Processes](../docs/processes/processes-main.md) describe validated lab protocols that either help you implement modules or just generally do useful things (see [Assemble Protein Mix](../docs/processes/make-36pot/main.md) as an example). 
 - [Implementations](../docs/implementations/implementations-main.md) describe particular uses of Modules in a specific context and using specific Processes (see [Responder: aTc -> ivhsl](../docs/implementations/responder-atc-ivhsl/main.md) as an example). 
 - [Guides](../guides/main.md) are narrative documentation describing how to do something generally useful (this page is a guide, for instance). We recommend exploring the four document categories to get a sense for how this site is organized.


### PR DESCRIPTION
Five internal links resolve to nothing on the live site. All are outside `docs/`, which is why they never showed up: the link check is normally run as `check-links.py docs/`, and a run scoped that way reports a clean pass while every one of these is broken.

| file | wrote | lands on |
| --- | --- | --- |
| `start/first-guide.md:23` | `./base-cytosol/spec` | `start/base-cytosol/spec` |
| `guides/kinetics-tutorial/main.md:5` | `guides/platereader-tutorial/` | `guides/kinetics-tutorial/guides/…` |
| `guides/platereader_tutorial.md:5` | `guides/kinetics-tutorial/` | `guides/guides/kinetics-tutorial` |
| `about/release-notes/v050.md:93,106` | `https://nucleus.bnext.biohttps://nucleus.bnext.bio/` | — |
| `guides/developer-notes/developer-notes.md:20` | `https://api.curvenote.com/login%E2%80%9D` | 404 |

Four are the same mistake — a relative path written as though it were root-relative. The tutorial pair also disagrees on a filename: the link hyphenates `platereader-tutorial` where the file is `platereader_tutorial.md`.

The developer-note line quotes terminal output, and a trailing `”` got URL-encoded into the href. It is now in backticks, which also stops the adjacent `<curvenote-email-account>` placeholder from parsing as a tag.

## Verifying

```bash
python3 scripts/check-links.py --offline-only .
```

Run it against the repo root, not `docs/`. Five findings remain, all `TODO` placeholders under `templates/` — scaffold, meant to dangle.

## Not fixed here

`scripts/check-myst-build.py` reports these alongside ~17 vendor HTTP 403 and 429 responses, which it treats as build errors. `CLAUDE.md`'s documented policy for `check-links.py` tolerates exactly those. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)