### PR TITLE
Write down the staged-edit review process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,27 @@ pre-commit install        # installs hooks (done automatically by setup.sh)
 pre-commit run --all-files  # run all hooks manually
 ```
 
+## Staged edits
+
+**Do not edit committed files directly when resolving a conflict or applying a ruling.** Write the proposal to a staging file in `tmp/` first, resolve the conflict there, and apply only when the developer explicitly says to.
+
+Scope: every committed file in this repo — `docs/`, `CLAUDE.md`, `STYLE-GUIDE.md`, `myst.yml`, `scripts/`. Files under `tmp/` are gitignored and may be edited directly. Other repos have their own conventions.
+
+A staging file records four things:
+
+1. **The ruling or finding**, quoted.
+2. **What it overturns**, quoted from the page it contradicts. This is the part that earns the file — an edit that silently overwrites a claim hides whether the claim had a rationale behind it, and a wrong claim with a rationale attached is more convincing than a blank.
+3. **The edit sites**, as a table of page, line, current text, proposed text.
+4. **What it leaves open**, including questions for the developer.
+
+**A ruling about what is true is not approval to apply it.** Settling a fact decides what the staging file should say; it does not authorize touching a page. The same holds for answers to questions raised inside the staging file — those close items in the proposal, not the review.
+
+**The commit is the fold-in.** One commit, after review, whose subject is applying the staging file — not edit, then commit, then discuss. If an edit lands before approval, revert it and then remove the revert as well: a commit that should not have existed should not leave a revert pair in the history.
+
+**Name a staging file's dependencies.** One review pass can produce edits that land in several files, and applying them in the wrong order can make a correct proposal wrong — line numbers in particular are only valid against an unchanged file.
+
+Naming: `tmp/STAGED-<date>-<topic>.md`.
+
 ## Architecture
 
 ### Companion DNA repository


### PR DESCRIPTION
One section in `CLAUDE.md`, 21 lines, no other file touched.

## Why

The process is already enforced in practice and written down nowhere. Searching `CLAUDE.md`, `STYLE-GUIDE.md`, every file under `style-guide/` and the project skills returns no mention of staging, intermediates or gating. It survives only as a shape you can infer from artifacts in `tmp/` — `ANSWERS-*.md` with its applied-log section, `DNA-STAGED/`, `proposed-diagrams/`.

A convention you have to reverse-engineer from artifacts is not a control. In one session on 2026-08-31 it was violated three times by an agent that believed it was following instructions, twice producing commits that had to be reverted — and one of those reverts then had to be removed from history, because a commit that should not have existed should not leave a revert pair behind.

## What the section says

The rule, its scope, the four things a staging file records, and two traps:

- **A ruling about what is true is not approval to apply it.** Settling a fact decides what the staging file should *say*; it does not authorize touching a page. Collapsing those is how "the developer confirmed the fact" becomes "the developer approved the edit," which is exactly how one of the three violations happened.
- **The commit is the fold-in** — one commit, after review, not edit-then-commit-then-discuss.

**Point 2 of the four is the one that earns the file: quote what is being overturned.** Two claims that fell during that session were false *and carried a chemical rationale*, and the rationale is what made them convincing. An edit that overwrites silently hides whether there was reasoning behind what it replaced — and a commit message shows the replacement, never what it replaced.

## Scope note

`scripts/` is listed as in scope. That is arguable — a checker fix is not a content claim, and staging one may be friction without benefit. Happy to drop it from the list if you would rather; it is the one line in here I would not defend hard.

## Related

- #236 proposes the check that would enforce this — flag a commit touching `docs/` whose message names no staging file. It needs its own PR and an announcement, since it changes the commit workflow for everyone.
- This is deliberately a micro-PR off `main` rather than part of #231, since the guidance is useful independently of the DevStudio content work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)