### PR TITLE
Site updates for v0.6 launch

### DIFF
--- a/about/release-notes.md
+++ b/about/release-notes.md
@@ -4,9 +4,11 @@ title: Release Notes
 
 # Current release
 
-- [🎊 What’s new in v0.5.0](./release-notes/v050.md) (*Release: January 8, 2026*)
+- [🎊 What’s new in v0.6.0](./release-notes/v060.md) (*Release: September 2026*)
 
 # Past releases
+
+- [🎊 What’s new in v0.5.0](./release-notes/v050.md) (*Release: January 8, 2026*)
 
 - [🎊 What’s new in v0.4.0](https://nucleus.bnext.bio/What-s-new-in-v0-4-0-23aae616eb51802a8628c928d8703fc7) (*Release: July 23, 2025*)
 - [🎊 What’s new in v0.3.0](https://nucleus.bnext.bio/What-s-new-in-v0-3-0-1b2ae616eb5180d2872ae51182052055) (*Release: March 12, 2025*)

--- a/about/release-notes/v060.md
+++ b/about/release-notes/v060.md
@@ -1,0 +1,88 @@
+---
+title: "What's new in Nucleus v0.6"
+subtitle: "Release: September 2026"
+---
+
+Nucleus v0.6 marks a significant step forward across the platform. Since January, the DevNote ecosystem has grown substantially — with contributions from the Nucleus team, the Developer Cell community, independent researchers, and for the first time, workshops and courses. The documentation migration from nucleus.bnext.bio to nucleus.engineering is complete. The Cell Development Kit ships its first major version update. Here's what's new.
+
+## Developer Notes
+
+### Nucleus Science
+
+New DevNotes from the Nucleus team characterize core Cytosol behaviors and expand the toolkit for synthetic cell development.
+
+**ClpXP Control Module: Deployment in Nucleus Cytosol:** Validation of the ClpXP protein degradation control module in Nucleus Cytosol reactions.
+
+- [**Read the DevNote**](https://devnotes.nucleus.engineering/articles/yh-20260626-01)
+
+**Characterizing the Limited Operational Lifetime of Cytosol Reactions:** A systematic characterization of how incubation time before encapsulation affects Cytosol reaction performance.
+
+- [**Read the DevNote**](https://devnotes.nucleus.engineering/articles/sy-20260624)
+
+**SecYEG-Based Membrane Translation Module in Synthetic Cells:** Development of a membrane translation module via reconstitution of the SecYEG translocon for enhanced membrane protein integration in liposomes.
+
+- [**Read the DevNote**](https://devnotes.nucleus.engineering/articles/yh-20260612-01)
+
+**Nucleus OnePot PURE:** Protocol and results from the Nucleus OnePot PURE workflow.
+
+- [**Read the DevNote**](https://devnotes.nucleus.engineering/articles/onepot-0407)
+
+**Using platemaps to analyze and share data:** Introduction of the first Nucleus platemap standard, enabling structured sharing of plate reader experimental data.
+
+- [**Read the DevNote**](https://devnotes.nucleus.engineering/articles/Bhasin-20260421)
+
+**Intro to Kinetics Analysis of Plate Reader Experiments:** A practical introduction to kinetics analysis of plate reader data using the CDK.
+
+- [**Read the DevNote**](https://devnotes.nucleus.engineering/articles/Newman-20260421)
+
+### Developer Cells
+
+Developer Cell community members have contributed results in Nucleus Cytosol, expanding the validated module library.
+
+**Double emulsion optimization: inner solution, lipid concentration, and composition:** Optimization of the double emulsion encapsulation workflow for producing GUVs.
+
+- [**Read the DevNote**](https://devnotes.nucleus.engineering/articles/mk0407)
+
+**Theophylline-LacZ sensor validation in Nucleus Cytosol:** Validation of a theophylline-responsive LacZ sensor in Nucleus PURE.
+
+- [**Read the DevNote**](https://devnotes.nucleus.engineering/articles/mn-260508-02)
+
+**TetO-Catecholase sensor validation in Nucleus Cytosol:** Validation of a TetR-regulated catecholase biosensor in Nucleus PURE.
+
+- [**Read the DevNote**](https://devnotes.nucleus.engineering/articles/mn-260508-01)
+
+### Community
+
+Independent contributions from the broader synthetic biology community, validated in Nucleus-compatible systems.
+
+**BCECF pH Sensor:** Adapting the ratiometric pH indicator BCECF to continuous, 24-hour kinetic pH tracking in cell-free reactions.
+
+- [**Read the DevNote**](https://devnotes.nucleus.engineering/articles/dg-20260805)
+
+**DNA toolkit — The T7 terminator collection:** Characterization of a collection of T7 terminator variants in PURE, enabling tunable transcription termination.
+
+- [**Read the DevNote**](https://devnotes.nucleus.engineering/articles/newell-2026-terminators)
+
+### Workshops and Courses
+
+This release introduces a new Workshops and Courses category for DevNotes, capturing hands-on educational work with Nucleus. Contributions this cycle include a Build a Cell workshop, a Cold Spring Harbor course, an undergraduate course at Cal Poly SLO, and a Developer Cell meeting in London.
+
+- [**Browse Workshops and Courses DevNotes**](https://devnotes.nucleus.engineering/collections-workshops-and-courses)
+
+## Documentation
+
+The migration of Nucleus documentation from [nucleus.bnext.bio](https://nucleus.bnext.bio) (Notion-based) to [nucleus.engineering](https://docs.nucleus.engineering) (MyST Markdown) is now substantially complete. All active protocols and module specifications are now maintained on the new site.
+
+This release also introduces the first **Nucleus platemap standard**, enabling structured, reproducible sharing of plate reader experimental layouts. The standard is introduced and demonstrated in the [Using platemaps to analyze and share data](https://devnotes.nucleus.engineering/articles/Bhasin-20260421) DevNote and supported by the CDK.
+
+The [FAQ](../../about/faqs.md) and [License](../../about/license.md) pages have been updated to reflect the current state of Nucleus governance and open-source licensing.
+
+## Cell Development Kit
+
+**CDK v0.6** is now available on PyPI:
+
+```
+pip install nucleus-cdk
+```
+
+v0.6 introduces support for the Nucleus platemap standard, updated kinetics analysis tools, and improved interoperability with the DevNote workflow. See the [CDK changelog](https://pypi.org/project/nucleus-cdk/) for the full list of changes.

--- a/docs/implementations/implementations-main.md
+++ b/docs/implementations/implementations-main.md
@@ -11,3 +11,4 @@ Implementations are combinations of useful Processes and Modules. This section i
 ## Implementations
 
 - [Responder Cell: aTc-detection IVHSL-emission](./responder-atc-ivhsl/main.md)
+- [Emitter Cell: IV-HSL emission](./emitter-ivhsl/main.md)

--- a/docs/modules/modules-main.md
+++ b/docs/modules/modules-main.md
@@ -19,6 +19,7 @@ Modules validated in [NEB PURExpress](https://www.neb.com/en-us/products/e6800-p
 | --------------- | ------------------------------------------- | ---------- |
 | Membrane (Base) | [POPC/Chol](./membrane-popc-chol/spec.md)   | ★★★        |
 | Detector        | [tetR-aTc](./detector-tetr_atc/spec.md)     | ★★         |
+|                 | [LacI-IPTG](./detector-laci_iptg/spec.md)   | ★★         |
 | Emitter         | [IV-HSL](./emitter-ivhsl/spec.md)           | ★★         |
 | Control         | [ClpXP](./control-clpxp/spec.md)            | ★★         |
 | Energy          | [PPK](./energy-ppk/spec.md)                 | ★          |

--- a/intro.md
+++ b/intro.md
@@ -5,13 +5,13 @@ site:
   hide_outline: true
 ---
 
-<a href="./about/release-notes/v050.md" class="version-badge">Nucleus v0.5.0</a>
+<a href="./about/release-notes/v060.md" class="version-badge">Nucleus v0.6.0</a> <a href="https://github.com/nucleus-eng/nucleus-docs/issues" class="version-badge">Improve the Docs</a> <a href="./about/license.md" class="version-badge">Open Source</a>
 
 Nucleus is an open platform for synthetic cell development, maintained by [b.next](https://bnext.bio). It brings together validated protocols, modular biological components, digital tools, and physical materials — everything you need to start building synthetic cells in one place. Platform tools make it easy to contribute new capabilities back to the distribution, documented for reuse and interoperable with Nucleus specifications.
 
 The underlying source for all Nucleus tools, designs, and documentation is available in the repositories at the [Nucleus GitHub organization](https://github.com/nucleus-eng).
 
-<a href="./start/first-guide.md" class="quick-link">Get started</a> <a href="./about/release-notes/v050.md" class="quick-link">🎊 What's new in v0.5.0</a> <a href="https://bnextbio.typeform.com/nucleus-signup" class="quick-link">Join the mailing list</a>
+<a href="./start/first-guide.md" class="quick-link">Get started</a> <a href="./about/release-notes/v060.md" class="quick-link">🎊 What's new in v0.6.0</a> <a href="https://bnextbio.typeform.com/nucleus-signup" class="quick-link">Join the mailing list</a>
 
 ---
 
@@ -20,7 +20,34 @@ The underlying source for all Nucleus tools, designs, and documentation is avail
 Nucleus Documentation is the protocol and specification library for the Nucleus Distribution. Here you'll find validated lab protocols, module specifications, and implementation guides for building synthetic cells using cytosol based on the PURE system. Documentation is built from [Developer Notes](https://devnotes.nucleus.engineering), the primary mechanism for contributing validated research to the Nucleus Distribution.
 
 
-### What's in the docs
+### ✨ Featured
+
+::::{grid} 1 1 3 3
+
+:::{card}
+:header: 🧱 **Modules**
+- [tetR-aTc Detector](docs/modules/detector-tetr_atc/spec.md)
+- [ClpXP Control Module](docs/modules/control-clpxp/spec.md)
+- [Cx43 Membrane Pore](docs/modules/membrane-pore-cx43/spec.md)
+:::
+
+:::{card}
+:header: ⚙️ **Processes**
+- [Encapsulation: Phase Transfer](docs/processes/assemble-base-cell/main.md)
+- [Assemble Base Cytosol](docs/processes/assemble-base-cytosol/main.md)
+- [Make Ribosomes](docs/processes/make-ribosomes/main.md)
+:::
+
+:::{card}
+:header: 🔬 **Cells**
+- [Responder Cell](docs/implementations/responder-atc-ivhsl/main.md)
+- [Emitter Cell](docs/implementations/emitter-ivhsl/main.md)
+- [Base Cell](docs/modules/base-cell/spec.md)
+:::
+
+::::
+
+### How the Docs are structured
 
 Nucleus Cytosol can be extended with Modules, assembled into Cells using Processes, and combined into Implementations. Supporting resources cover the DNA Distribution, software tools, and guides.
 
@@ -68,42 +95,4 @@ Tutorials, how-tos, and workshop materials for using the Nucleus Distribution an
 
 ::::
 
----
-
-## Platform
-
-The Nucleus platform makes it possible to access tools and workflows, contribute technical content, and engage with members of the Nucleus community.
-
-::::{grid} 1 1 1 4
-
-:::{card}
-:header: 📖 **Documentation**
-:link: #documentation
-
-Lab protocols, module specifications, and implementation guides for the Nucleus Distribution.
-:::
-
-:::{card}
-:header: 🔬 **Hub**
-:link: https://hub.nucleus.engineering
-
-Where Nucleus developers design, analyze, and collaborate.
-:::
-
-:::{card}
-:header: 📝 **Developer Notes**
-:link: https://devnotes.nucleus.engineering
-
-Contributions to the Nucleus Platform from labs and developers worldwide.
-:::
-
-:::{card}
-:header: 💬 **Forum**
-:link: https://forum.nucleus.engineering
-
-Discussions, questions, and announcements from the Nucleus community.
-:::
-
-::::
-
-Supported by the Astera Institute, National Science Foundation, Schmidt Sciences, and the Sloan Foundation. [Contact us](mailto:build@bnext.bio) to request access to materials or get involved with the community on the [Forum](https://forum.nucleus.engineering).
+Supported by the Astera Institute, National Science Foundation, Schmidt Sciences, and the Sloan Foundation. [Contact us](mailto:build@bnext.bio) to request access to materials or to get involved.

--- a/myst.yml
+++ b/myst.yml
@@ -119,6 +119,8 @@ project:
     - file: ./about/faqs.md
     - file: ./about/release-notes.md
       children:
+        - file: ./about/release-notes/v060.md
+          hidden: true
         - file: ./about/release-notes/v050.md
           hidden: true
     - file: ./about/contributors.md

--- a/site.yml
+++ b/site.yml
@@ -8,15 +8,11 @@ project:
 site:
   url: https://docs.nucleus.engineering
   template: book-theme
-  nav: 
+  nav:
     - title: Documentation
       url: https://docs.nucleus.engineering/
-    - title: Hub
-      url: https://hub.nucleus.engineering/
     - title: Developer Notes
       url: https://devnotes.nucleus.engineering/
-    - title: Forum
-      url: https://forum.nucleus.engineering/
     - title: Contribute
       url: /start/contribute
     # - title: Help

--- a/start/contribute.md
+++ b/start/contribute.md
@@ -2,6 +2,8 @@
 title: Contribute
 ---
 
+Synthetic cell development advances faster when protocols, data, and tools are shared openly. Contributing to Nucleus means your work doesn't stay in a notebook — it gets documented, validated, and made available to every lab building with the Distribution. Whether you have a result to share, a bug to fix, or an idea to propose, here's where to start.
+
 There are several ways to contribute to Nucleus: through Developer Notes, issues and pull requests on our repos, and discussion on the Forum. Here's where to start, depending on what you're looking to do.
 
 ## Share a result (DevNote)


### PR DESCRIPTION
## Summary

Homepage and navigation updates ahead of the v0.6 launch.

**Navigation**
- Remove Hub and Forum buttons from nav (both are being deprioritized)

**Homepage**
- Add v0.6.0 version badge; add Open Source (→ license page) and Improve the Docs (→ GitHub issues) badges
- Add ✨ Featured section with example Modules, Processes, and Cells
- Remove Platform section (Hub/Forum cards no longer relevant)
- Rename "What's in the docs" → "How the Docs are structured"
- Add context paragraph to Contribute page

**Release Notes**
- Add v0.6.0 release notes covering: Nucleus Science DevNotes, Developer Cell contributions, Community DevNotes, Workshops & Courses category, docs migration completion, platemap standard, CDK v0.6
- Move v0.5.0 to Past Releases in the index

**Bug fixes**
- Restore LacI-IPTG Detector to modules-main.md PURExpress table (was dropped in a prior merge)
- Add Emitter Cell to implementations-main.md (directory existed but wasn't indexed)

## Notes
- DevNote links in v0.6 release notes are filled in except for the toehold riboregulator entry (omitted pending patent notice update on that collection page)
- Roadmap page deferred to a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)