### PR TITLE
Polish v0.6 release notes and homepage copy

### DIFF
--- a/about/release-notes/v060.md
+++ b/about/release-notes/v060.md
@@ -3,13 +3,9 @@ title: "What's new in Nucleus v0.6"
 subtitle: "Release: September 2026"
 ---
 
-Nucleus v0.6 marks a significant step forward across the platform. Since January, the DevNote ecosystem has grown substantially — with contributions from the Nucleus team, the Developer Cell community, independent researchers, and for the first time, workshops and courses. The documentation migration from nucleus.bnext.bio to nucleus.engineering is complete. The Cell Development Kit ships its first major version update. Here's what's new.
+Nucleus v0.6 marks a significant step forward across the platform. Since January, the DevNote ecosystem has grown substantially — with contributions from the b.next team, the Developer Cell community, independent researchers, and for the first time, workshops and courses. The documentation migration from nucleus.bnext.bio to nucleus.engineering is complete. The Cell Development Kit ships its first major version update. Here's what's new.
 
 ## Developer Notes
-
-### Nucleus Science
-
-New DevNotes from the Nucleus team characterize core Cytosol behaviors and expand the toolkit for synthetic cell development.
 
 **ClpXP Control Module: Deployment in Nucleus Cytosol:** Validation of the ClpXP protein degradation control module in Nucleus Cytosol reactions.
 
@@ -35,10 +31,6 @@ New DevNotes from the Nucleus team characterize core Cytosol behaviors and expan
 
 - [**Read the DevNote**](https://devnotes.nucleus.engineering/articles/Newman-20260421)
 
-### Developer Cells
-
-Developer Cell community members have contributed results in Nucleus Cytosol, expanding the validated module library.
-
 **Double emulsion optimization: inner solution, lipid concentration, and composition:** Optimization of the double emulsion encapsulation workflow for producing GUVs.
 
 - [**Read the DevNote**](https://devnotes.nucleus.engineering/articles/mk0407)
@@ -50,10 +42,6 @@ Developer Cell community members have contributed results in Nucleus Cytosol, ex
 **TetO-Catecholase sensor validation in Nucleus Cytosol:** Validation of a TetR-regulated catecholase biosensor in Nucleus PURE.
 
 - [**Read the DevNote**](https://devnotes.nucleus.engineering/articles/mn-260508-01)
-
-### Community
-
-Independent contributions from the broader synthetic biology community, validated in Nucleus-compatible systems.
 
 **BCECF pH Sensor:** Adapting the ratiometric pH indicator BCECF to continuous, 24-hour kinetic pH tracking in cell-free reactions.
 

--- a/docs/implementations/implementations-main.md
+++ b/docs/implementations/implementations-main.md
@@ -5,7 +5,7 @@ description: Documented combinations of Nucleus modules and processes demonstrat
 
 # Overview
 
-Implementations are Cells, and other useful combinations of Modules and Processes. 
+Implementations are combinations of useful Processes and Modules. This section is intended to capture where multiple modules have been operated together or characterized under a variety of operating conditions. 
 
 
 ## Implementations

--- a/docs/implementations/implementations-main.md
+++ b/docs/implementations/implementations-main.md
@@ -5,7 +5,7 @@ description: Documented combinations of Nucleus modules and processes demonstrat
 
 # Overview
 
-Implementations are combinations of useful Processes and Modules. This section is intended to capture where multiple modules have been operated together or characterized under a variety of operating conditions. 
+Implementations are Cells, and other useful combinations of Modules and Processes. 
 
 
 ## Implementations

--- a/intro.md
+++ b/intro.md
@@ -5,13 +5,11 @@ site:
   hide_outline: true
 ---
 
-<a href="./about/release-notes/v060.md" class="version-badge">Nucleus v0.6.0</a> <a href="https://github.com/nucleus-eng/nucleus-docs/issues" class="version-badge">Improve the Docs</a> <a href="./about/license.md" class="version-badge">Open Source</a>
+<a href="./about/release-notes/v060.md" class="version-badge">Nucleus v0.6.0</a> <a href="./about/license.md" class="version-badge">Open Source</a>
 
 Nucleus is an open platform for synthetic cell development, maintained by [b.next](https://bnext.bio). It brings together validated protocols, modular biological components, digital tools, and physical materials — everything you need to start building synthetic cells in one place. Platform tools make it easy to contribute new capabilities back to the distribution, documented for reuse and interoperable with Nucleus specifications.
 
-The underlying source for all Nucleus tools, designs, and documentation is available in the repositories at the [Nucleus GitHub organization](https://github.com/nucleus-eng).
-
-<a href="./start/first-guide.md" class="quick-link">Get started</a> <a href="./about/release-notes/v060.md" class="quick-link">🎊 What's new in v0.6.0</a> <a href="https://bnextbio.typeform.com/nucleus-signup" class="quick-link">Join the mailing list</a>
+<a href="./start/first-guide.md" class="quick-link">Get started</a> <a href="./about/release-notes/v060.md" class="quick-link">🎊 What's new in v0.6.0</a> <a href="https://github.com/nucleus-eng" class="quick-link">GitHub</a> <a href="https://bnextbio.typeform.com/nucleus-signup" class="quick-link">Join the mailing list</a>
 
 ---
 

--- a/intro.md
+++ b/intro.md
@@ -66,7 +66,7 @@ Processes are core protocols for implementing Base Cytosol and Cells.
 :::{card}
 :header: 🏗️ **Implementations**
 :link: docs/implementations/implementations-main.md
-Implementations are useful combinations of Modules and Processes.
+Implementations are Cells, and other useful combinations of Modules and Processes.
 :::
 
 ::::


### PR DESCRIPTION
## Summary

- **v0.6 release notes**: flatten DevNote sections — remove institution-based subsections (Nucleus Science, Developer Cells, Community), keep Workshops & Courses callout; update intro paragraph to reference b.next team instead of "Nucleus team"
- **Homepage**: remove "Improve the Docs" badge and standalone GitHub paragraph; add GitHub as a quick-link button alongside Get started / What's new / Join the mailing list
- **implementations-main.md**: rewrite description to lead with Cells — "Implementations are Cells, and other useful combinations of Modules and Processes"

🤖 Generated with [Claude Code](https://claude.com/claude-code)