### PR TITLE
Fix DevNote reference URLs and ignore tmp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ dep/
 # DevNote numbered export folders (e.g. 09-cx43_cell/) — raw exports, never committed
 **/resources/[0-9][0-9]-*/
 
+# Staging and scratch — never committed (see CLAUDE.md, "Staged edits")
+tmp/

--- a/myst.yml
+++ b/myst.yml
@@ -126,11 +126,11 @@ project:
     - file: ./about/contributors.md
     - file: ./about/license.md
   references:
-    devnote-01: https://devnotes.bnext.bio/articles/019a7511-0b68-702b-8909-0fe96ef8d5d2
-    devnote-02: https://devnotes.bnext.bio/articles/ppk-module-test
-    devnote-deGFP-cells: https://devnotes.nucleus.engineering/articles/bnext-devnotes-base-cell-01
-    devnote-cx43: https://devnotes.bnext.bio/articles/019a7496-0498-7d89-bebb-58cdc15caf54
-    devnote-devcell-plan: https://devnotes.bnext.bio/articles/developer-cell-introduction
+    devnote-01: https://devnotes.nucleus.engineering/articles/fppr8928
+    devnote-02: https://devnotes.nucleus.engineering/articles/ppk-module-test
+    devnote-deGFP-cells: https://devnotes.nucleus.engineering/articles/base-cell-01
+    devnote-cx43: https://devnotes.nucleus.engineering/articles/cx43-cell-01
+    devnote-devcell-plan: https://devnotes.nucleus.engineering/articles/developer-cell-introduction
   resources:
     - docs/**/*
 


### PR DESCRIPTION
Two small chores, unrelated to each other. Split out of #255, which does not cause either one.

## DevNote references — this is what is red on #255

The `build-protocols` job fails on five myst errors:

```
⛔️ myst.yml Unable to load reference "devnote-deGFP-cells"
⛔️ myst.yml Unable to load reference "devnote-cx43"
⛔️ myst.yml Unable to load reference "devnote-01"
⛔️ docs/modules/membrane-pore-cx43/spec.md Cannot embed "xref:devnote-cx43#fig:scheme"
⛔️ docs/modules/reporter-degfp/spec.md:39 Cannot embed "xref:devnote-01#rc"
```

The last two follow from the first three.

**Cause.** The DevNotes site re-slugged its articles and moved off `devnotes.bnext.bio`. The old URLs still redirect, but `<old-url>/myst.xref.json` returns the site HTML instead of JSON, so myst cannot read the reference. This is rot on the DevNotes side, not CI flakiness.

All five keys now point at their current `devnotes.nucleus.engineering` URL:

| Key | Was | Now |
| --- | --- | --- |
| `devnote-01` | `devnotes.bnext.bio/articles/019a7511-…` | `devnotes.nucleus.engineering/articles/fppr8928` |
| `devnote-02` | `devnotes.bnext.bio/articles/ppk-module-test` | `devnotes.nucleus.engineering/articles/ppk-module-test` |
| `devnote-deGFP-cells` | `…/articles/bnext-devnotes-base-cell-01` | `…/articles/base-cell-01` |
| `devnote-cx43` | `devnotes.bnext.bio/articles/019a7496-…` | `devnotes.nucleus.engineering/articles/cx43-cell-01` |
| `devnote-devcell-plan` | `devnotes.bnext.bio/articles/developer-cell-introduction` | `devnotes.nucleus.engineering/articles/developer-cell-introduction` |

Each was checked: final URL 200, `myst.xref.json` 200 and valid JSON.

**Correction to an earlier version of this description.** It claimed a local `myst build --html` reported zero reference and zero embed errors. That build never ran — the local `myst` shim is the curvenote CLI and its auth token is expired, which aborts the build before it emits anything. The grep returned zero because there was no output to match. The real verification is CI: `build-protocols` passes on this branch and fails on every other open PR with exactly the five errors above.

`devnote-02` and `devnote-devcell-plan` were not in the error list, because myst only loads a reference a page actually cites. They are updated anyway so the block stays consistent, and so the same failure does not reappear when a page starts citing them.

## .gitignore

`tmp/` was never ignored. `git status -uall tmp/` listed 421 untracked files, so `git add -A` would have staged all of them.

`CLAUDE.md` already says files under `tmp/` are gitignored. This makes that true rather than changing policy.

Happy to split these into two PRs if you would rather review them apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
