### PR TITLE
Add the composition source, its checker, and one page that exercises it

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -59,3 +59,23 @@ jobs:
 
       - name: Check TOC
         run: python3 scripts/check-toc.py
+
+  composition:
+    # The prose `## Constituent Modules` list and the machine-readable `spec.yml`
+    # are two sources for one fact, and they drift. Blocks when the prose names a
+    # module the source never does; reports without blocking when the final step
+    # has an operand the prose omits, which is a grain difference rather than an
+    # error. See scripts/check-composition.py.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install pyyaml
+        run: pip install pyyaml
+
+      - name: Check composition sources
+        run: python3 scripts/check-composition.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,13 +45,17 @@ CI runs on pushes to `main` via `.github/workflows/deploy.yml`, installing `myst
 
 **QA checks** (run locally before opening a PR):
 ```bash
-python3 scripts/check-dropdowns.py      # flag placeholder-only lists
-python3 scripts/check-file-placement.py # flag content files outside allowed dirs
-python3 scripts/check-toc.py            # validate myst.yml TOC entries
-python3 scripts/check-dna-refs.py       # if you touched a Designs table: verify construct/bp claims against nucleus-eng/DNA
+python3 scripts/check-dropdowns.py      # (CI) flag placeholder-only lists
+python3 scripts/check-file-placement.py # (CI) flag content files outside allowed dirs
+python3 scripts/check-toc.py            # (CI) validate myst.yml TOC entries
+python3 scripts/check-composition.py    # (CI) if you touched a spec.yml or a Constituent Modules list
+python3 scripts/check-dna-refs.py       # (local) if you touched a Designs table: verify construct/bp claims against nucleus-eng/DNA
 ```
 
-These run automatically on PRs via `.github/workflows/qa.yml` (which also runs Vale). Install pre-commit hooks to catch violations before pushing:
+**The four marked `(CI)` run automatically on PRs** via `.github/workflows/qa.yml`, which
+also runs Vale. **`check-dna-refs.py` runs in no workflow** — deliberately, because a
+commit in `nucleus-eng/DNA` could turn it red with no change here (see the DNA section
+below). Run it by hand before opening a PR. Install pre-commit hooks to catch violations before pushing:
 ```bash
 pre-commit install        # installs hooks (done automatically by setup.sh)
 pre-commit run --all-files  # run all hooks manually
@@ -433,6 +437,51 @@ Tolerated failures are normal and expected: a clean run currently reports ~120 o
 - **Soft-404s are invisible** — a vendor serving "product not found" with HTTP 200 reads as a healthy link.
 
 Both still require manual review. `lychee` is pinned to 0.24.2 in both workflows because its JSON report is this script's input contract and has changed shape between releases before (#136); bump the pin and the local install together.
+
+### Composition sources
+
+A module may carry a `spec.yml` beside its `spec.md`: the machine-readable composition
+(#248), naming the process that performs each combination step and the operator it
+applies. `scripts/render-composition.py` draws the diagram from it and writes it into the
+`gen:composition-diagram` markers on that page.
+
+```bash
+python3 scripts/render-composition.py docs/modules/<module>/spec.yml            # print the mermaid
+python3 scripts/render-composition.py docs/modules/<module>/spec.yml --embed    # write it into spec.md
+python3 scripts/render-composition.py docs/modules/<module>/spec.yml --depth 2  # expand the leaves too
+```
+
+**The pairing is `spec.md` for humans, `spec.yml` for tooling** (Jon, 2026-09-11). That is
+one file per module carrying composition and, in time, requirements — not a separate
+`requirements.yml`. The prose `## Constituent Modules` list stays for readers, so nothing
+makes the two agree on its own: `python3 scripts/check-composition.py` checks that they do
+not disagree. It blocks when the prose lists a module the source never names — the live
+failure was `london-cascade` claiming `Substrate: CPRG` where its source said `GUV: CPRG`,
+an hour after both existed — and reports without blocking when the final step has an
+operand the prose omits, which is a grain difference rather than an error.
+
+**Diagrams render at depth 1.** Anything you can obtain is a leaf; only what the module
+builds on the way to its own result is expanded. Base Cytosol is a leaf for the same
+reason S30 Lysate is — it is a thing you can have, and its own page says how. Having a page
+is *not* the test. Deeper renders are for review material, never for a docs page. A module
+whose composition is a single box gets no diagram at all.
+
+**The keys in use.** No schema file and no validator — this table is the record, and a key
+not listed here is new.
+
+| Level | Keys |
+| --- | --- |
+| top | `module`, `title`, `inputs`, `steps`; `measured_by`; `open` |
+| step | `id`, `process`, `operator`, `operands`, `produces`; `notes`; `parameters`; `headroom`; `ratio` |
+| input | `title`, `page`; `component_of` where a component has no page of its own; `owner` |
+
+**A number belongs in `spec.yml` when it states a fact no single constituent page can
+state.** `headroom.capacity` is a property of the Module that provides the slot — not of
+the process that filled it, and not of any additive, since the process that spends a slot
+is usually not the one that made it. A combining `ratio` is a property of the step. An
+osmolarity that has to match across a membrane is a relation. Those belong here. A
+preparation figure that already sits on its own page does not, and duplicating it is how
+the two drift.
 
 ### DNA reference checking
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -460,6 +460,14 @@ failure was `london-cascade` claiming `Substrate: CPRG` where its source said `G
 an hour after both existed — and reports without blocking when the final step has an
 operand the prose omits, which is a grain difference rather than an error.
 
+**The scripts are named for the concern they check, not the file they read.**
+`check-composition.py` and `render-composition.py` both read `spec.yml` and both handle
+composition only — what composes, by which process, under which operator. They are not
+misnamed, and renaming them to match the file would be the change that does not scale:
+`spec.yml` is the container, and composition is one concern inside it. When requirements
+land in the same file, `check-requirements.py` (#223) reads it for a different concern and
+sits beside these two.
+
 **Diagrams render at depth 1.** Anything you can obtain is a leaf; only what the module
 builds on the way to its own result is expanded. Base Cytosol is a leaf for the same
 reason S30 Lysate is — it is a thing you can have, and its own page says how. Having a page

--- a/docs/modules/base-cell/spec.md
+++ b/docs/modules/base-cell/spec.md
@@ -22,6 +22,38 @@ Overview of Base Cell, composed of [Base Cytosol](/docs/modules/base-cytosol/spe
 
 :::::{tab-set}
 
+<!-- gen:composition-diagram -->
+::::{tab-item} Module Dependencies
+
+```mermaid
+flowchart TD
+    BASE_CYTOSOL["Base Cytosol"]
+    MEMBRANE_POPC_CHOL["Base Membrane"]
+
+    P1_ENCAPSULATE_0(["Encapsulation: Phase Transfer (packing)"])
+    BASE_CELL["Base Cell"]
+
+    BASE_CYTOSOL --> P1_ENCAPSULATE_0
+    MEMBRANE_POPC_CHOL --> P1_ENCAPSULATE_0
+    P1_ENCAPSULATE_0 --> BASE_CELL
+
+
+    classDef leaf     fill:#e5e7eb,stroke:#6b7280,color:#111827;
+    classDef composed fill:#6b7280,stroke:#374151,color:#ffffff;
+    classDef process  fill:#ffffff,stroke:#374151,color:#111827;
+    class BASE_CYTOSOL,MEMBRANE_POPC_CHOL leaf;
+    class BASE_CELL composed;
+    class P1_ENCAPSULATE_0 process;
+
+    click BASE_CYTOSOL "/docs/modules/base-cytosol/spec"
+    click MEMBRANE_POPC_CHOL "/docs/modules/membrane-popc-chol/spec"
+    click P1_ENCAPSULATE_0 "/docs/processes/assemble-base-cell/main"
+    click BASE_CELL "/docs/modules/base-cell/spec"
+```
+
+::::
+<!-- /gen:composition-diagram -->
+
 ::::{tab-item} Cytosol
 
 The inner solution encapsulated into the Base Cell is [Base Cytosol](/docs/modules/base-cytosol/spec.md) at reaction concentration, with `pOpen-deGFP` DNA added as a reporter.
@@ -72,6 +104,11 @@ See [Base Membrane](../membrane-popc-chol/spec.md) for the full membrane spec.
 ::::
 
 :::::
+
+## Constituent Modules
+
+- [Base Cytosol](../base-cytosol/spec.md) — inner solution, encapsulated at reaction concentration
+- [Base Membrane](../membrane-popc-chol/spec.md) — 70:30 POPC:cholesterol bilayer
 
 ## Expected Behavior
 

--- a/docs/modules/base-cell/spec.yml
+++ b/docs/modules/base-cell/spec.yml
@@ -1,0 +1,37 @@
+# Composition source for the Base Cell.
+#
+# Machine-readable companion to spec.md — see issue #248. The `# Constituent
+# Modules` prose stays for humans; this file is the contract for tooling, and
+# scripts/check-composition.py checks the two do not disagree.
+#
+# Operators.
+#   mixing   both at once, in one compartment, sharing its resources
+#   packing  both at once, each keeping its own compartment
+#
+# Depth 1. Both constituents are obtained.
+
+module: base-cell
+title: Base Cell
+
+inputs:
+  base-cytosol:
+    title: "Base Cytosol"
+    page: ../base-cytosol/spec.md
+  membrane-popc-chol:
+    title: "Base Membrane"
+    page: ../membrane-popc-chol/spec.md
+
+steps:
+  - id: encapsulate
+    process:
+      title: "Encapsulation: Phase Transfer"
+      page: ../../processes/assemble-base-cell/main.md
+    operator: packing
+    operands: [base-cytosol, membrane-popc-chol]
+    produces:
+      id: base-cell
+      title: "Base Cell"
+      page: ../base-cell/spec.md
+    notes: >
+      Base Cytosol at reaction concentration, closed in a 70:30
+      POPC:cholesterol bilayer.

--- a/scripts/check-composition.py
+++ b/scripts/check-composition.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Check each module's `# Constituent Modules` prose against its spec.yml.
+
+Jon ruled on 2026-09-09 that the prose section stays for humans while the yml
+is the contract for tooling (#248). Two sources for one fact drift, and this one
+already did: `london-cascade` listed `Substrate: CPRG` where its own source said
+`GUV: CPRG`, within an hour of both existing. Nothing caught it, because every
+other check in this repo validates one file against itself.
+
+Two findings, and they are not the same severity.
+
+  MISSING   a module the prose lists that the source never mentions.
+            Blocking. The prose is asserting a constituent the build does not
+            have, which is what went wrong on london-cascade.
+
+  UNLISTED  an operand of the final step, with a page, that the prose omits.
+            Reported, not blocking. The final step's operands are the direct
+            constituents, so the prose should usually name them — but a page
+            may legitimately describe its constituents at a different grain.
+            `chicago-cascade` names two Cascades where the source names the two
+            gel pieces they end as, and neither is wrong.
+
+Exit 0 nothing blocking, 1 a MISSING, 2 the check could not run.
+
+    python3 scripts/check-composition.py
+    python3 scripts/check-composition.py docs/modules/london-cascade
+"""
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("PyYAML not installed — cannot run (exit 2)")
+
+
+def repo_root() -> Path:
+    out = subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                         capture_output=True, text=True)
+    if out.returncode:
+        sys.exit("not inside a git repository (exit 2)")
+    return Path(out.stdout.strip())
+
+
+def slug_of(page: str | None) -> str | None:
+    """`../guv-cprg/spec.md` -> `guv-cprg`. Only module pages have a slug."""
+    if not page:
+        return None
+    m = re.search(r"\.\./([A-Za-z0-9._-]+)/spec\.md$", page)
+    return m.group(1) if m else None
+
+
+def prose_constituents(text: str) -> list[str]:
+    """Slugs bullet-linked under `# Constituent Modules`, in order.
+
+    Only bullets count. A link in the surrounding prose is a mention, not a
+    declaration — the same rule gen-module-diagrams.py uses.
+    """
+    m = re.search(r"^#+\s*Constituent Modules\s*$(.*?)(?=^#|\Z)", text, re.M | re.S)
+    if not m:
+        return []
+    out = []
+    for line in m.group(1).splitlines():
+        if not line.lstrip().startswith(("-", "*")):
+            continue
+        link = re.search(r"\]\(\.\./([A-Za-z0-9._-]+)/spec\.md", line)
+        if link and link.group(1) not in out:
+            out.append(link.group(1))
+    return out
+
+
+def source_slugs(doc: dict) -> tuple[set[str], set[str]]:
+    """(every module the source names, the final step's operands with pages)."""
+    named, pages = set(), {}
+    for key, v in (doc.get("inputs") or {}).items():
+        if (s := slug_of(v.get("page"))):
+            named.add(s)
+            pages[key] = s
+    for step in doc.get("steps") or []:
+        out = step["produces"]
+        if (s := slug_of(out.get("page"))):
+            named.add(s)
+            pages[out["id"]] = s
+    steps = doc.get("steps") or []
+    direct = {pages[o] for o in steps[-1]["operands"] if o in pages} if steps else set()
+    return named, direct
+
+
+def check(spec: Path, src: Path) -> tuple[list[str], list[str]]:
+    doc = yaml.safe_load(src.read_text(encoding="utf-8"))
+    named, direct = source_slugs(doc)
+    listed = prose_constituents(spec.read_text(encoding="utf-8"))
+    missing = [s for s in listed if s not in named]
+    unlisted = sorted(s for s in direct if s not in listed)
+    return missing, unlisted
+
+
+def main() -> int:
+    root = repo_root()
+    targets = [Path(a) for a in sys.argv[1:] if not a.startswith("-")]
+    roots = targets or [root / "docs" / "modules"]
+    sources = sorted({p for r in roots for p in Path(r).rglob("spec.yml")})
+    if not sources:
+        print(f"no spec.yml under {', '.join(str(r) for r in roots)}")
+        return 0
+
+    blocking, reported = 0, 0
+    for src in sources:
+        spec = src.parent / "spec.md"
+        if not spec.is_file():
+            print(f"⛔️ {src.parent.name}: spec.yml with no spec.md")
+            blocking += 1
+            continue
+        missing, unlisted = check(spec, src)
+        for s in missing:
+            print(f"⛔️ {spec}: '# Constituent Modules' lists {s}, "
+                  f"which spec.yml never names")
+            blocking += 1
+        for s in unlisted:
+            print(f"⚠️  {spec}: {s} is an operand of the final step "
+                  f"but is not in '# Constituent Modules'")
+            reported += 1
+
+    n = len(sources)
+    if blocking:
+        print(f"\n⛔️ {blocking} blocking, {reported} reported, {n} source(s) checked")
+        return 1
+    print(f"\n✅ prose agrees with source. {reported} reported, {n} source(s) checked")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/render-composition.py
+++ b/scripts/render-composition.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Render a module's spec.yml to a Mermaid flowchart.
+
+Reads the machine-readable composition source (#248) and writes the diagram
+into the `gen:composition-diagram` markers on that module's spec.md (#249).
+Idempotent: re-running with no source change rewrites the same block.
+
+There is a second generator, `gen-module-diagrams.py` in `nucleus-skills`,
+which derives its graph from the `# Constituent Modules` bullet list instead.
+The two will drift. See issue #250.
+
+Follows the house style in the `mermaid-diagrams` skill:
+  - Modules are boxes, processes are stadiums `([...])`. Never diamonds or
+    hexagons: a diamond reads as a decision point.
+  - Grayscale. Two shades — lighter for leaves, darker for things built from
+    other things. Shape already separates modules from processes, so color
+    would be encoding nothing.
+  - Ids are UPPER_SNAKE, derived mechanically, never taken from prose.
+  - Arrows run from constituent to container.
+  - No status claims. `-->` only. `-.->` and `--x` mean "proposed" and
+    "blocked", so using either decoratively asserts something unchecked.
+
+Depth. A module page shows `--depth 1` by default: anything you can obtain is a
+leaf, and only what this module builds on the way to its own result is
+expanded. Base Cytosol is a leaf at depth 1 for the same reason S30 Lysate is —
+it is a thing you can have, and its own page says how. `--depth 2` follows each
+leaf's own spec.yml where one exists, and so on. Deeper renders are for
+review material, not for module pages.
+
+    python3 scripts/render-composition.py docs/modules/london-cascade/spec.yml
+    python3 scripts/render-composition.py <path>/spec.yml --embed
+    python3 scripts/render-composition.py <path>/spec.yml --depth 3
+"""
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+STYLE = """
+    classDef leaf     fill:#e5e7eb,stroke:#6b7280,color:#111827;
+    classDef composed fill:#6b7280,stroke:#374151,color:#ffffff;
+    classDef process  fill:#ffffff,stroke:#374151,color:#111827;
+"""
+
+
+def node_id(slug: str) -> str:
+    return re.sub(r"[^A-Za-z0-9]", "_", slug).upper()
+
+
+def esc(s: str) -> str:
+    return s.replace('"', "'")
+
+
+def click_path(page: str | None) -> str | None:
+    """`../s30-lysate/spec.md` -> `/docs/modules/s30-lysate/spec`.
+
+    Matches the form the existing generated diagrams already use.
+    """
+    if not page:
+        return None
+    p = re.sub(r"\.md$", "", page)
+    p = re.sub(r"^\.\./\.\./", "/docs/", p)
+    p = re.sub(r"^\.\./", "/docs/modules/", p)
+    return p
+
+
+def chain(step: dict) -> list[dict]:
+    """The processes a step runs, in order. Usually one."""
+    return step["process"].get("composed_of") or [step["process"]]
+
+
+def expand(doc: dict, depth: int, root: Path) -> dict:
+    """Splice each leaf's own spec.yml in, `depth - 1` times over.
+
+    A leaf qualifies if it names a module page and that module has a source of
+    its own. Its final step produces the leaf, so that product is renamed to
+    the id the parent already uses and the two graphs join at one node.
+    """
+    if depth <= 1:
+        return doc
+    inputs = dict(doc.get("inputs") or {})
+    steps = list(doc["steps"])
+    for key, v in list(inputs.items()):
+        page = v.get("page")
+        if not page:
+            continue
+        sub_path = (root / page).resolve().parent / "spec.yml"
+        if not sub_path.is_file():
+            continue
+        sub = expand(yaml.safe_load(sub_path.read_text()), depth - 1, sub_path.parent)
+        # The leaf stops being an input; the sub-graph produces it instead.
+        del inputs[key]
+        produced = sub["steps"][-1]["produces"]["id"]
+        for s in sub["steps"]:
+            if s["produces"]["id"] == produced:
+                s["produces"] = {**s["produces"], "id": key}
+            s["operands"] = [key if o == produced else o for o in s["operands"]]
+        inputs.update(sub.get("inputs") or {})
+        steps = sub["steps"] + steps
+    return {**doc, "inputs": inputs, "steps": steps}
+
+
+def render(doc: dict) -> str:
+    L = ["flowchart TD"]
+    leaves, composed, procs, clicks = [], [], [], []
+
+    def declare(nid, label, page, bucket, shape="box"):
+        body = f'(["{esc(label)}"])' if shape == "stadium" else f'["{esc(label)}"]'
+        L.append(f"    {nid}{body}")
+        bucket.append(nid)
+        if (c := click_path(page)):
+            clicks.append((nid, c))
+
+    for key, v in (doc.get("inputs") or {}).items():
+        declare(node_id(key), v["title"], v.get("page"), leaves)
+
+    L.append("")
+    for i, s in enumerate(doc["steps"], 1):
+        pn = f"P{i}_{node_id(s['id'])}"
+        # The operator rides on the process node, because it is a property of
+        # the process rather than of any one edge.
+        # A step may run a chain of processes. Each gets its own node, so each
+        # keeps its own page link — a node takes only one click target.
+        for k, sub in enumerate(chain(s)):
+            # The step's operator belongs to whichever sub-process performs the
+            # composition, which is the first unless one says otherwise. A later
+            # link in the chain that composes nothing shows no operator, which
+            # is the honest reading rather than a borrowed one.
+            op = sub.get("operator", s["operator"] if k == 0 else None)
+            label = f'{sub["title"]} ({op})' if op else sub["title"]
+            # "no page" is stated in words. A dashed border would say
+            # "proposed", a status claim this diagram has not checked.
+            if not sub.get("page"):
+                label += " — no page"
+            declare(f"{pn}_{k}", label, sub.get("page"), procs, shape="stadium")
+        out = s["produces"]
+        declare(node_id(out["id"]), out["title"], out.get("page"), composed)
+
+    L.append("")
+    for i, s in enumerate(doc["steps"], 1):
+        pn = f"P{i}_{node_id(s['id'])}"
+        n = len(chain(s))
+        # Operands feed the first process; the chain runs; the last produces.
+        for op in s["operands"]:
+            L.append(f"    {node_id(op)} --> {pn}_0")
+        for k in range(n - 1):
+            L.append(f"    {pn}_{k} --> {pn}_{k + 1}")
+        lbl = f'|"{s["ratio"]}"|' if s.get("ratio") else ""
+        L.append(f'    {pn}_{n - 1} -->{lbl} {node_id(s["produces"]["id"])}')
+        L.append("")
+
+    # `measured_by` is deliberately not drawn. It produces no Module, so a plain
+    # edge would read as composition, and a dashed one would assert status.
+
+    L.append(STYLE.rstrip("\n"))
+    for name, ids in (("leaf", leaves), ("composed", composed), ("process", procs)):
+        if ids:
+            L.append(f"    class {','.join(ids)} {name};")
+    L.append("")
+    L += [f'    click {n} "{p}"' for n, p in clicks]
+    return "\n".join(L)
+
+
+BEGIN = "<!-- gen:composition-diagram -->"
+END = "<!-- /gen:composition-diagram -->"
+
+
+def page_block(mermaid: str) -> str:
+    """The tab-item the docs page carries, wrapped in the idempotency markers.
+
+    Plain ```mermaid fence: the directive form renders blank in Obsidian, and
+    this repo is 18 plain to 2 directive.
+    """
+    return (f"{BEGIN}\n::::{{tab-item}} Module Dependencies\n\n"
+            f"```mermaid\n{mermaid}\n```\n\n::::\n{END}")
+
+
+def embed(spec: Path, mermaid: str) -> bool | None:
+    """Rewrite the marked block. None if the page carries no markers.
+
+    A page with a composition source but no markers is a real finding, not a
+    crash: it means nobody decided where its diagram goes.
+    """
+    t = spec.read_text()
+    if BEGIN not in t or END not in t:
+        return None
+    i, j = t.index(BEGIN), t.index(END) + len(END)
+    new = t[:i] + page_block(mermaid) + t[j:]
+    if new == t:
+        return False
+    spec.write_text(new)
+    return True
+
+
+if __name__ == "__main__":
+    src = Path(sys.argv[1])
+    depth = 1
+    if "--depth" in sys.argv:
+        depth = int(sys.argv[sys.argv.index("--depth") + 1])
+    doc = expand(yaml.safe_load(src.read_text()), depth, src.parent)
+    mermaid = render(doc)
+    if "--embed" in sys.argv:
+        spec = src.parent / "spec.md"
+        r = embed(spec, mermaid)
+        verdict = {None: "NO MARKERS — nowhere to put it",
+                   True: "updated", False: "unchanged"}[r]
+        print(f"{verdict}: {spec}")
+    else:
+        print(mermaid)


### PR DESCRIPTION
The machine-readable composition source from #248, brought to `main` as its own change rather than riding in with the DevCells corpus. Infrastructure and content have different reviewers and different risk, and #231 mixes them.

Sized to be reviewable in one sitting: two scripts, one CI job, one page, one doc correction.

## What is here

**`scripts/render-composition.py`** — draws a module's composition diagram from its `spec.yml` and writes it into the `gen:composition-diagram` markers. Modules are boxes, processes are stadiums, greyscale, depth 1 by default.

**`scripts/check-composition.py`** — compares the prose `## Constituent Modules` list against the source. Blocks when the prose names a module the source never does; reports without blocking when the final step has an operand the prose omits, which is a grain difference rather than an error.

**The checker runs in `qa.yml`.** It was written on 2026-09-09 and has run in no workflow since, which left the only guard against prose/source drift opt-in. That drift is not hypothetical — `london-cascade` claimed `Substrate: CPRG` where its own source said `GUV: CPRG`, within an hour of both existing, and nothing caught it because every other check in this repo validates one file against itself.

**`base-cell` gets the first source.** Without a single source on `main` the check would pass on an empty set and rot unnoticed. It now reports `1 source(s) checked`.

## Why `base-cell`

It is the cheapest possible first case:

- **Every page its source names is already on `main`** — `base-cytosol`, `membrane-popc-chol`, and the `assemble-base-cell` process. Nothing new is introduced.
- **It claims nothing new.** The two constituents and the process are already stated in the page's own Overview: *"The Base Cell is Base Cytosol encapsulated in Base Membrane via Encapsulation: Phase Transfer."* The source records what the page already says, so there is nothing to review on the science.
- It is `status: validated-published`, the most settled page in the corpus.

The page gains a `## Constituent Modules` section and a generated diagram as the first tab of its existing Reference Composition tab-set. `##` matches its own neighbours on `main`; if the corpus is later flattened to H1, this flattens with it, and the checker matches `^#+` either way.

## A documentation correction

`CLAUDE.md` said four QA checks *"run automatically on PRs via `.github/workflows/qa.yml`"*. `check-dna-refs.py` does not, and **the same file says so further down** — *"Local-only — not run in CI, since CI has no DNA-repo checkout."* A reader was told both things. Each line is now marked `(CI)` or `(local)` with the reason.

## On the file name

`spec.md` for humans, `spec.yml` for tooling. That states the prose/contract split in the filenames instead of a convention someone has to be told, and it settles #248's open question by implication — one file per module carries composition and, in time, requirements, so there is no separate `requirements.yml`.

## Verified on this branch

| Check | Result |
| --- | --- |
| `check-composition.py` | exit 0 — 1 source checked, prose agrees |
| `check-dropdowns.py` | exit 0 |
| `check-file-placement.py` | exit 0 |
| `check-toc.py` | exit 0 |
| `check-links.py --offline-only` | exit 0 — 0 broken |
| `qa.yml` | parses |

## Related

#248 the source · #250 two generators, two sources · #209 the original · #226 the same move for three other checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)